### PR TITLE
Add uv-based project configuration

### DIFF
--- a/docs/testing-async-falcon-endpoints.md
+++ b/docs/testing-async-falcon-endpoints.md
@@ -43,10 +43,10 @@ my\_falcon\_project/
 │   ├── conftest.py       \# Shared pytest fixtures  
 │   └── test\_resources.py \# Test file for resources  
 ├──.venv/                \# Virtual environment  
-├── requirements.txt      \# Project dependencies  
+├── pyproject.toml        \# Project metadata and dependencies managed by uv
 └── pytest.ini            \# Pytest configuration (optional)
 
-This structure separates application code from test code, and conftest.py can house shared fixtures accessible across multiple test files. A similar structure is often suggested for web applications, promoting modularity.
+This structure separates application code from test code, and conftest.py can house shared fixtures accessible across multiple test files. Dependencies are declared in ``pyproject.toml`` and installed with ``uv sync``. A similar structure is often suggested for web applications, promoting modularity.
 
 ### **Configuring pytest-asyncio**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[project]
+name = "bournemouth"
+version = "0.1.0"
+description = "Raggy Graph Chat"
+readme = "README.md"
+requires-python = ">=3.13"
+license = { file = "COPYING" }
+authors = [{ name = "Payton McIntosh", email = "pmcintosh@df12.net" }]
+dependencies = [
+  "falcon>=3.1",
+  "SQLAlchemy>=2.0",
+  "asyncpg>=0.29",
+  "neo4j>=5.20",
+  "requests>=2.31"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+  "pytest-asyncio>=0.23",
+  "httpx>=0.27",
+  "pytest-mock",
+  "ruff>=0.4.3",
+  "pyright"
+]
+docs = [
+  "sphinx>=5.0",
+  "sphinx-rtd-theme"
+]
+
+[project.scripts]
+# placeholder for future CLI entry points
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.uv]
+package = true
+
+[tool.pyright]
+typeCheckingMode = "strict"
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "RUF"]
+


### PR DESCRIPTION
## Summary
- create an initial `pyproject.toml`
- document `pyproject.toml` and `uv sync` in testing guide

## Testing
- `npx @biomejs/biome check . --apply`
- `npx tsc --noEmit`
- `pytest -q`
- `pyright`


------
https://chatgpt.com/codex/tasks/task_e_683f62a2634c83229e53eea469364039

## Summary by Sourcery

Introduce UV-based project configuration by adding a pyproject.toml with tooling and dependency settings, and update documentation to guide users on using pyproject.toml and uv sync.

Enhancements:
- Add initial pyproject.toml with project metadata and dependency declarations
- Configure build system requirements, UV packaging, strict Pyright type checking, and Ruff linting in pyproject.toml

Documentation:
- Update testing guide to reference pyproject.toml and install dependencies with uv sync instead of requirements.txt