### PR TITLE
Improve README details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # bournemouth
-Raggy Graph Chat
+
+Bournemouth is an experimental chat application that combines retrieval-augmented generation with a novelty-aware knowledge graph. The goal is to store new facts discovered in conversation and recall them with sub-second latency.
+
+## Architecture
+
+The system comprises a few lightweight services:
+
+1. **chat-api** – A Falcon ASGI app written for Python 3.13. It exposes `/chat`, `/auth/openrouter-token`, and `/health` endpoints, embeds queries, retrieves context from Neo4j, and proxies prompts to an LLM via OpenRouter.
+2. **worker** – Processes background tasks such as entity extraction and graph updates using asynchronous SQLAlchemy.
+3. **neo4j** – Hosts the knowledge graph and vector indexes for similarity search.
+4. **postgres** – Stores user accounts, OpenRouter tokens, and audit logs. It can also serve as a fallback vector store via `pgvector`.
+5. **traefik** – Handles TLS termination and rate limiting when deployed.
+
+A detailed discussion of this architecture and the scaling path is available in [`docs/mvp-architecture.md`](docs/mvp-architecture.md) and [`docs/mid-level-design.md`](docs/mid-level-design.md).
+
+## Development
+
+Dependencies are managed with [uv](https://github.com/astral-sh/uv). After installing `uv`, set up the environment with:
+
+```bash
+uv sync
+```
+
+Run the API locally with:
+
+```bash
+uv run python -m bournemouth.app
+```
+
+Testing strategies and additional guides live in the `docs/` directory, including:
+
+- [`docs/testing-async-falcon-endpoints.md`](docs/testing-async-falcon-endpoints.md) for pytest usage.
+- [`docs/async-sqlalchemy-with-pg-and-falcon.md`](docs/async-sqlalchemy-with-pg-and-falcon.md) for asynchronous database access.
+- [`docs/embedding-with-hf-tei.md`](docs/embedding-with-hf-tei.md) for generating embeddings with Hugging Face TEI.


### PR DESCRIPTION
## Summary
- describe the overall service architecture
- note how to set up the environment and run the API
- reference design and testing docs

## Testing
- `npx -y @biomejs/biome check README.md` *(fails: No files were processed)*
- `npx -y tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_683f6f27ad348322a26d12e8942009b8

## Summary by Sourcery

Enhance the README with architectural details, development setup instructions, and references to design and testing documentation.

Documentation:
- Expand the project description to explain the retrieval-augmented chat application and knowledge graph objectives.
- Introduce an Architecture section detailing the chat-api, worker, Neo4j, Postgres, and Traefik components.
- Add Development instructions for environment setup using uv and running the API locally.
- Reference existing design and testing guides in the docs directory.