### PR TITLE
Fix deprecated ruff select config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,5 +50,7 @@ reportAttributeAccessIssue = false
 
 [tool.ruff]
 line-length = 88
+
+[tool.ruff.lint]
 select = ["E", "F", "RUF"]
 


### PR DESCRIPTION
## Summary
- move `tool.ruff` `select` list into new `[tool.ruff.lint]` section

## Testing
- `ruff check .`
- `pyright`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_683f7808ddf8832285d5f1c1ed8e9ac6

## Summary by Sourcery

Bug Fixes:
- Migrate the `select` list from the old `tool.ruff` table to `tool.ruff.lint` to resolve deprecation