### PR TITLE
Add login with session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
 # bournemouth
 
-Bournemouth is an experimental chat application that combines retrieval-augmented generation with a novelty-aware knowledge graph. The goal is to store new facts discovered in conversation and recall them with sub-second latency.
+Bournemouth is an experimental chat application that combines
+retrieval-augmented generation with a novelty-aware knowledge graph. The goal is
+to store new facts discovered in conversation and recall them with sub-second
+latency.
 
 ## Architecture
 
 The system comprises a few lightweight services:
 
-1. **chat-api** – A Falcon ASGI app written for Python 3.13. It exposes `/chat`, `/auth/openrouter-token`, and `/health` endpoints, embeds queries, retrieves context from Neo4j, and proxies prompts to an LLM via OpenRouter.
-2. **worker** – Processes background tasks such as entity extraction and graph updates using asynchronous SQLAlchemy.
+1. **chat-api** – A Falcon ASGI app written for Python 3.13. It exposes `/chat`,
+   `/auth/openrouter-token`, and `/health` endpoints. It embeds queries,
+   retrieves context from Neo4j and proxies prompts to an LLM via OpenRouter.
+2. **worker** – Processes background tasks such as entity extraction and graph
+   updates using asynchronous SQLAlchemy.
 3. **neo4j** – Hosts the knowledge graph and vector indexes for similarity search.
-4. **postgres** – Stores user accounts, OpenRouter tokens, and audit logs. It can also serve as a fallback vector store via `pgvector`.
+4. **postgres** – Stores user accounts, OpenRouter tokens, and audit logs. It can
+   also serve as a fallback vector store via `pgvector`.
 5. **traefik** – Handles TLS termination and rate limiting when deployed.
 
-A detailed discussion of this architecture and the scaling path is available in [`docs/mvp-architecture.md`](docs/mvp-architecture.md) and [`docs/mid-level-design.md`](docs/mid-level-design.md).
+A detailed discussion of this architecture and the scaling path is available in
+[`docs/mvp-architecture.md`](docs/mvp-architecture.md) and
+[`docs/mid-level-design.md`](docs/mid-level-design.md).
 
 ## Development
 
-Dependencies are managed with [uv](https://github.com/astral-sh/uv). After installing `uv`, set up the environment with:
+Dependencies are managed with [uv](https://github.com/astral-sh/uv). After
+installing `uv`, set up the environment with:
 
 ```bash
 uv sync
@@ -28,8 +38,23 @@ Run the API locally with:
 uv run python -m bournemouth.app
 ```
 
+The server exposes a `/login` endpoint that accepts HTTP Basic Auth credentials.
+On success it returns a signed `session` cookie used by the middleware to guard
+all other routes except `/health`. The credentials, session secret and timeout
+can be configured via environment variables:
+
+```bash
+export LOGIN_USER=admin
+export LOGIN_PASSWORD=adminpass
+export SESSION_SECRET="$(openssl rand -base64 32)"
+export SESSION_TIMEOUT=3600
+```
+
 Testing strategies and additional guides live in the `docs/` directory, including:
 
-- [`docs/testing-async-falcon-endpoints.md`](docs/testing-async-falcon-endpoints.md) for pytest usage.
-- [`docs/async-sqlalchemy-with-pg-and-falcon.md`](docs/async-sqlalchemy-with-pg-and-falcon.md) for asynchronous database access.
-- [`docs/embedding-with-hf-tei.md`](docs/embedding-with-hf-tei.md) for generating embeddings with Hugging Face TEI.
+- [`docs/testing-async-falcon-endpoints.md`](docs/testing-async-falcon-endpoints.md)
+  for pytest usage.
+- [`docs/async-sqlalchemy-with-pg-and-falcon.md`](docs/async-sqlalchemy-with-pg-and-falcon.md)
+  for asynchronous database access.
+- [`docs/embedding-with-hf-tei.md`](docs/embedding-with-hf-tei.md)
+  for generating embeddings with Hugging Face TEI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
   "SQLAlchemy>=2.0",
   "asyncpg>=0.29",
   "neo4j>=5.20",
-  "requests>=2.31"
+  "requests>=2.31",
+  "itsdangerous>=2.1"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "itsdangerous>=2.1"
 ]
 
+  "freezegun>=1.4",
 
 [dependency-groups]
 dev = [

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -6,6 +6,7 @@ from falcon import asgi
 
 import base64
 import os
+from typing import Optional
 
 
 from .resources import ChatResource, OpenRouterTokenResource, HealthResource
@@ -13,17 +14,37 @@ from .auth import AuthMiddleware, LoginResource
 from .session import SessionManager
 
 
-def create_app() -> asgi.App:
-    """Configure and return the Falcon ASGI app."""
+def create_app(
+    *,
+    session_secret: Optional[str] = None,
+    session_timeout: Optional[int] = None,
+    login_user: Optional[str] = None,
+    login_password: Optional[str] = None,
+) -> asgi.App:
+    """Configure and return the Falcon ASGI app.
 
-    secret = os.getenv("SESSION_SECRET")
+    Parameters
+    ----------
+    session_secret:
+        Secret used to sign session cookies. If omitted, ``SESSION_SECRET``
+        from the environment is used or a random value is generated.
+    session_timeout:
+        Cookie expiration in seconds. Defaults to ``SESSION_TIMEOUT`` from the
+        environment or ``3600`` seconds.
+    login_user:
+        Expected Basic Auth username. Defaults to ``LOGIN_USER`` or ``admin``.
+    login_password:
+        Expected Basic Auth password. Defaults to ``LOGIN_PASSWORD`` or
+        ``adminpass``.
+    """
+
+    secret = session_secret or os.getenv("SESSION_SECRET")
     if secret is None:
         secret_bytes = os.urandom(32)
         secret = base64.urlsafe_b64encode(secret_bytes).decode()
-    timeout = int(os.getenv("SESSION_TIMEOUT", "3600"))
-    login_user = os.getenv("LOGIN_USER", "admin")
-    login_password = os.getenv("LOGIN_PASSWORD", "adminpass")
-
+    timeout = session_timeout or int(os.getenv("SESSION_TIMEOUT", "3600"))
+    user = login_user or os.getenv("LOGIN_USER", "admin")
+    password = login_password or os.getenv("LOGIN_PASSWORD", "adminpass")
     session = SessionManager(secret, timeout)
     middleware = [AuthMiddleware(session)]
     app = asgi.App(middleware=middleware)
@@ -31,5 +52,5 @@ def create_app() -> asgi.App:
     app.add_route("/chat", ChatResource())
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource())
     app.add_route("/health", HealthResource())
-    app.add_route("/login", LoginResource(session, login_user, login_password))
+    app.add_route("/login", LoginResource(session, user, password))
     return app

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
-import falcon
+from falcon import asgi
+
+import os
 
 from .resources import ChatResource, OpenRouterTokenResource, HealthResource
+from .auth import AuthMiddleware, LoginResource
+from .session import SessionManager
 
 
-def create_app() -> falcon.asgi.App:
+def create_app() -> asgi.App:
     """Configure and return the Falcon ASGI app."""
 
-    app = falcon.asgi.App()
+    secret = os.getenv("SESSION_SECRET", "dev-secret")
+    timeout = int(os.getenv("SESSION_TIMEOUT", "3600"))
+    login_user = os.getenv("LOGIN_USER", "admin")
+    login_password = os.getenv("LOGIN_PASSWORD", "adminpass")
+
+    session = SessionManager(secret, timeout)
+    middleware = [AuthMiddleware(session)]
+    app = asgi.App(middleware=middleware)
+
     app.add_route("/chat", ChatResource())
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource())
     app.add_route("/health", HealthResource())
+    app.add_route("/login", LoginResource(session, login_user, login_password))
     return app

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from falcon import asgi
 
+import base64
 import os
+
 
 from .resources import ChatResource, OpenRouterTokenResource, HealthResource
 from .auth import AuthMiddleware, LoginResource
@@ -14,7 +16,10 @@ from .session import SessionManager
 def create_app() -> asgi.App:
     """Configure and return the Falcon ASGI app."""
 
-    secret = os.getenv("SESSION_SECRET", "dev-secret")
+    secret = os.getenv("SESSION_SECRET")
+    if secret is None:
+        secret_bytes = os.urandom(32)
+        secret = base64.urlsafe_b64encode(secret_bytes).decode()
     timeout = int(os.getenv("SESSION_TIMEOUT", "3600"))
     login_user = os.getenv("LOGIN_USER", "admin")
     login_password = os.getenv("LOGIN_PASSWORD", "adminpass")

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import base64
+import typing
+from http import HTTPStatus
 
 import falcon
 
@@ -25,7 +27,7 @@ class AuthMiddleware:
         if cookie is None:
             raise falcon.HTTPUnauthorized()
 
-        user = self._session.verify_cookie(cookie)
+        user = self._session.verify_cookie(typing.cast(str, cookie))
         if user is None:
             raise falcon.HTTPUnauthorized()
 
@@ -47,8 +49,8 @@ class LoginResource:
             raise falcon.HTTPUnauthorized()
 
         try:
-            encoded = auth_header[len(prefix) :]
-            decoded_bytes = base64.b64decode(encoded.encode())
+            encoded = typing.cast(str, auth_header[len(prefix) :])
+            decoded_bytes = base64.b64decode(encoded)
             decoded = decoded_bytes.decode()
             username, password = decoded.split(":", 1)
         except Exception:
@@ -65,4 +67,5 @@ class LoginResource:
             http_only=True,
             same_site="Lax",
         )
+        resp.status = HTTPStatus.OK
         resp.media = {"status": "logged_in"}

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import typing
 from http import HTTPStatus
 
 import falcon
@@ -22,7 +23,7 @@ class AuthMiddleware:
         if req.path in {"/health", "/login"}:
             return
 
-        cookie = req.cookies.get("session")
+        cookie = typing.cast(str | None, req.cookies.get("session"))
         if cookie is None:
             raise falcon.HTTPUnauthorized()
 
@@ -48,7 +49,7 @@ class LoginResource:
             raise falcon.HTTPUnauthorized()
 
         try:
-            encoded = auth_header[len(prefix) :]
+            encoded = typing.cast(str, auth_header[len(prefix) :])
             decoded_bytes = base64.b64decode(encoded)
             decoded = decoded_bytes.decode()
             username, password = decoded.split(":", 1)

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import typing
 from http import HTTPStatus
 
 import falcon
@@ -27,7 +26,7 @@ class AuthMiddleware:
         if cookie is None:
             raise falcon.HTTPUnauthorized()
 
-        user = self._session.verify_cookie(typing.cast(str, cookie))
+        user = self._session.verify_cookie(cookie)
         if user is None:
             raise falcon.HTTPUnauthorized()
 
@@ -49,7 +48,7 @@ class LoginResource:
             raise falcon.HTTPUnauthorized()
 
         try:
-            encoded = typing.cast(str, auth_header[len(prefix) :])
+            encoded = auth_header[len(prefix) :]
             decoded_bytes = base64.b64decode(encoded)
             decoded = decoded_bytes.decode()
             username, password = decoded.split(":", 1)

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -1,0 +1,68 @@
+"""Authentication middleware and login resource."""
+
+from __future__ import annotations
+
+import base64
+
+import falcon
+
+from .session import SessionManager
+
+__all__ = ["AuthMiddleware", "LoginResource"]
+
+
+class AuthMiddleware:
+    """Require a valid session cookie for all routes except health and login."""
+
+    def __init__(self, session: SessionManager) -> None:
+        self._session = session
+
+    async def process_request(self, req: falcon.Request, resp: falcon.Response) -> None:
+        if req.path in {"/health", "/login"}:
+            return
+
+        cookie = req.cookies.get("session")
+        if cookie is None:
+            raise falcon.HTTPUnauthorized()
+
+        user = self._session.verify_cookie(cookie)
+        if user is None:
+            raise falcon.HTTPUnauthorized()
+
+        req.context["user"] = user
+
+
+class LoginResource:
+    """Authenticate via Basic Auth and set a signed session cookie."""
+
+    def __init__(self, session: SessionManager, user: str, password: str) -> None:
+        self._session = session
+        self._user = user
+        self._password = password
+
+    async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
+        auth_header = req.get_header("Authorization") or ""
+        prefix = "Basic "
+        if not auth_header.startswith(prefix):
+            raise falcon.HTTPUnauthorized()
+
+        try:
+            encoded = auth_header[len(prefix) :]
+            decoded_bytes = base64.b64decode(encoded.encode())
+            decoded = decoded_bytes.decode()
+            username, password = decoded.split(":", 1)
+        except Exception:
+            raise falcon.HTTPUnauthorized()
+
+        if username != self._user or password != self._password:
+            raise falcon.HTTPUnauthorized()
+
+        token = self._session.create_cookie(username)
+        resp.set_cookie(
+            "session",
+            token,
+            max_age=self._session.timeout,
+            http_only=True,
+            same_site="Lax",
+        )
+        resp.media = {"status": "logged_in"}

--- a/src/bournemouth/session.py
+++ b/src/bournemouth/session.py
@@ -1,0 +1,37 @@
+"""Utility for managing signed session cookies."""
+
+from __future__ import annotations
+
+import typing
+
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+__all__ = ["SessionManager"]
+
+
+class SessionManager:
+    """Create and verify session cookies."""
+
+    def __init__(self, secret: str, timeout: int) -> None:
+        self._serializer = URLSafeTimedSerializer(secret)
+        self.timeout = timeout
+
+    def create_cookie(self, username: str) -> str:
+        """Return a signed cookie value for *username*."""
+        return self._serializer.dumps({"u": username})
+
+    def verify_cookie(self, cookie: str) -> str | None:
+        """Return the username if *cookie* is valid and not expired."""
+        try:
+            data = typing.cast(
+                dict[str, typing.Any],
+                self._serializer.loads(cookie, max_age=self.timeout),
+            )
+        except SignatureExpired:
+            return None
+        except BadSignature:
+            return None
+        user = data.get("u")
+        if isinstance(user, str):
+            return user
+        return None

--- a/src/bournemouth/session.py
+++ b/src/bournemouth/session.py
@@ -18,7 +18,8 @@ class SessionManager:
 
     def create_cookie(self, username: str) -> str:
         """Return a signed cookie value for *username*."""
-        return self._serializer.dumps({"u": username})
+        token = self._serializer.dumps({"u": username})
+        return typing.cast(str, token)
 
     def verify_cookie(self, cookie: str) -> str | None:
         """Return the username if *cookie* is valid and not expired."""

--- a/src/bournemouth/session.py
+++ b/src/bournemouth/session.py
@@ -19,7 +19,7 @@ class SessionManager:
     def create_cookie(self, username: str) -> str:
         """Return a signed cookie value for *username*."""
         token = self._serializer.dumps({"u": username})
-        return typing.cast(str, token)
+        return token
 
     def verify_cookie(self, cookie: str) -> str | None:
         """Return the username if *cookie* is valid and not expired."""

--- a/src/bournemouth/unittests/test_session.py
+++ b/src/bournemouth/unittests/test_session.py
@@ -16,3 +16,16 @@ def test_cookie_expiry() -> None:
     cookie = mgr.create_cookie("alice")
     time.sleep(2)
     assert mgr.verify_cookie(cookie) is None
+
+def test_cookie_bad_signature_with_different_secret() -> None:
+    mgr1 = SessionManager("secret1", 10)
+    mgr2 = SessionManager("secret2", 10)
+    cookie = mgr1.create_cookie("alice")
+    assert mgr2.verify_cookie(cookie) is None
+
+
+def test_cookie_bad_signature_when_tampered() -> None:
+    mgr = SessionManager("secret", 10)
+    cookie = mgr.create_cookie("alice")
+    tampered = cookie + "tamper"
+    assert mgr.verify_cookie(tampered) is None

--- a/src/bournemouth/unittests/test_session.py
+++ b/src/bournemouth/unittests/test_session.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import time
+
+from bournemouth.session import SessionManager
+
+
+def test_cookie_roundtrip() -> None:
+    mgr = SessionManager("secret", 10)
+    cookie = mgr.create_cookie("alice")
+    assert mgr.verify_cookie(cookie) == "alice"
+
+
+def test_cookie_expiry() -> None:
+    mgr = SessionManager("secret", 1)
+    cookie = mgr.create_cookie("alice")
+    time.sleep(2)
+    assert mgr.verify_cookie(cookie) is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from typing import Any, cast
+
+from bournemouth.app import create_app
+
+
+@pytest.mark.asyncio
+async def test_login_sets_cookie() -> None:
+    app = create_app()
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)),  # pyright: ignore[reportUnknownArgumentType]
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.post(
+            "/login", headers={"Authorization": f"Basic {credentials}"}
+        )
+    assert resp.status_code == 200
+    assert "session" in resp.cookies
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_bad_credentials() -> None:
+    app = create_app()
+    credentials = base64.b64encode(b"admin:wrong").decode()
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)),  # pyright: ignore[reportUnknownArgumentType]
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.post(
+            "/login", headers={"Authorization": f"Basic {credentials}"}
+        )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_protected_endpoint_requires_cookie() -> None:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)),  # pyright: ignore[reportUnknownArgumentType]
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.post("/chat", json={"message": "hi"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_chat_with_valid_session() -> None:
+    app = create_app()
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)),  # pyright: ignore[reportUnknownArgumentType]
+        base_url="http://test",
+    ) as ac:
+        login_resp = await ac.post(
+            "/login", headers={"Authorization": f"Basic {credentials}"}
+        )
+        session_cookie = login_resp.cookies.get("session")
+        assert session_cookie is not None
+        chat_resp = await ac.post(
+            "/chat",
+            json={"message": "hi"},
+            cookies={"session": session_cookie},
+        )
+    assert chat_resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_health_does_not_require_auth() -> None:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=cast(Any, app)),  # pyright: ignore[reportUnknownArgumentType]
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.get("/health")
+    assert resp.status_code == 200

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from http import HTTPStatus
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -20,7 +21,7 @@ async def test_login_sets_cookie() -> None:
         resp = await ac.post(
             "/login", headers={"Authorization": f"Basic {credentials}"}
         )
-    assert resp.status_code == 200
+    assert resp.status_code == HTTPStatus.OK
     assert "session" in resp.cookies
 
 
@@ -35,7 +36,7 @@ async def test_login_rejects_bad_credentials() -> None:
         resp = await ac.post(
             "/login", headers={"Authorization": f"Basic {credentials}"}
         )
-    assert resp.status_code == 401
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @pytest.mark.asyncio
@@ -46,7 +47,7 @@ async def test_protected_endpoint_requires_cookie() -> None:
         base_url="http://test",
     ) as ac:
         resp = await ac.post("/chat", json={"message": "hi"})
-    assert resp.status_code == 401
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 
 @pytest.mark.asyncio
@@ -67,7 +68,7 @@ async def test_chat_with_valid_session() -> None:
             json={"message": "hi"},
             cookies={"session": session_cookie},
         )
-    assert chat_resp.status_code == 200
+    assert chat_resp.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio
@@ -78,4 +79,4 @@ async def test_health_does_not_require_auth() -> None:
         base_url="http://test",
     ) as ac:
         resp = await ac.get("/health")
-    assert resp.status_code == 200
+    assert resp.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary
- implement signed cookie sessions via `SessionManager`
- add basic-auth login endpoint and middleware
- guard routes with session middleware
- test session creation and auth flow
- add itsdangerous dependency

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7606090c8322b7919db45284de68

## Summary by Sourcery

Add cookie-based session authentication by implementing a SessionManager, login endpoint, and middleware, and add tests for the new auth flow.

New Features:
- Introduce SessionManager to handle signed cookie sessions
- Add LoginResource endpoint for Basic Auth login that issues session cookies
- Implement AuthMiddleware to protect routes based on valid session cookies

Build:
- Add itsdangerous dependency for cookie signing

Tests:
- Add integration tests for login flow, protected routes, and health endpoint
- Add unit tests for session cookie creation, verification, and expiration