### PR TITLE
Switch to PEP 735 dependency groups

### DIFF
--- a/docs/testing-async-falcon-endpoints.md
+++ b/docs/testing-async-falcon-endpoints.md
@@ -43,10 +43,10 @@ my\_falcon\_project/
 │   ├── conftest.py       \# Shared pytest fixtures  
 │   └── test\_resources.py \# Test file for resources  
 ├──.venv/                \# Virtual environment  
-├── pyproject.toml        \# Project metadata and dependencies managed by uv
+├── pyproject.toml        \# Project metadata, dependencies, and PEP 735 groups managed by uv
 └── pytest.ini            \# Pytest configuration (optional)
 
-This structure separates application code from test code, and conftest.py can house shared fixtures accessible across multiple test files. Dependencies are declared in ``pyproject.toml`` and installed with ``uv sync``. A similar structure is often suggested for web applications, promoting modularity.
+This structure separates application code from test code, and conftest.py can house shared fixtures accessible across multiple test files. Dependencies and dependency groups (PEP 735) are declared in ``pyproject.toml`` and installed with ``uv sync``. A similar structure is often suggested for web applications, promoting modularity.
 
 ### **Configuring pytest-asyncio**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
   "requests>=2.31"
 ]
 
-[project.optional-dependencies]
+
+[dependency-groups]
 dev = [
   "pytest>=7.0",
   "pytest-asyncio>=0.23",


### PR DESCRIPTION
## Summary
- use `[dependency-groups]` instead of `[project.optional-dependencies]`
- document the use of dependency groups in the testing guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7d0e32c083229995e75b634ecee5

## Summary by Sourcery

Switch to PEP 735 dependency groups for development dependencies and update the testing guide accordingly

Enhancements:
- Replace `project.optional-dependencies` with PEP 735 `dependency-groups` in pyproject.toml

Documentation:
- Document the use of dependency groups in the testing guide