### PR TITLE
Return proper status for placeholder endpoints

### DIFF
--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import falcon
+from falcon import asgi
 
 from .resources import ChatResource, OpenRouterTokenResource, HealthResource
 
 
-def create_app() -> falcon.asgi.App:
+def create_app() -> asgi.App:
     """Configure and return the Falcon ASGI app."""
 
-    app = falcon.asgi.App()
+    app = asgi.App()
     app.add_route("/chat", ChatResource())
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource())
     app.add_route("/health", HealthResource())

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -24,8 +24,11 @@ class ChatResource:
         if not data or "message" not in data:
             raise falcon.HTTPBadRequest(description="`message` field required")
 
-        # TODO: plug in RAG and LLM call
-        resp.media = {"answer": "This is a placeholder response."}
+        # TODO(pmcintosh): plug in RAG and LLM call
+        # https://github.com/example/repo/issues/1
+        raise falcon.HTTPNotImplemented(
+            description="This endpoint is not yet implemented."
+        )
 
 
 class OpenRouterTokenResource:
@@ -36,8 +39,10 @@ class OpenRouterTokenResource:
         if not data or "api_key" not in data:
             raise falcon.HTTPBadRequest(description="`api_key` field required")
 
-        # TODO: persist the token for the authenticated user
-        resp.media = {"status": "stored"}
+        # TODO(pmcintosh): persist the token for the authenticated user
+        raise falcon.HTTPNotImplemented(
+            description="This endpoint is not yet implemented."
+        )
 
 
 class HealthResource:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from http import HTTPStatus
+from falcon import asgi
+import typing
+
+from bournemouth.app import create_app
+
+
+@pytest.fixture()
+def app() -> asgi.App:
+    return create_app()
+
+
+@pytest.mark.asyncio
+async def test_chat_not_implemented(app: asgi.App) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast(typing.Any, app)),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post("/chat", json={"message": "hello"})
+    assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
+    assert (
+        resp.json()["title"]
+        == f"{HTTPStatus.NOT_IMPLEMENTED.value} {HTTPStatus.NOT_IMPLEMENTED.phrase}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_missing_message(app: asgi.App) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast(typing.Any, app)),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post("/chat", json={})
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_store_token_not_implemented(app: asgi.App) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast(typing.Any, app)),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post("/auth/openrouter-token", json={"api_key": "xyz"})
+    assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
+    assert (
+        resp.json()["title"]
+        == f"{HTTPStatus.NOT_IMPLEMENTED.value} {HTTPStatus.NOT_IMPLEMENTED.phrase}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_token_missing_key(app: asgi.App) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast(typing.Any, app)),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post("/auth/openrouter-token", json={})
+    assert resp.status_code == HTTPStatus.BAD_REQUEST


### PR DESCRIPTION
## Summary
- raise `HTTPNotImplemented` from unimplemented endpoints
- test placeholder endpoints with httpx
- use `HTTPStatus` constants in tests
- import Falcon ASGI helpers properly

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7e473ec08322a6438a8ffdac780c