### PR TITLE
Fix failing tests

### DIFF
--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -25,7 +25,7 @@ class AuthMiddleware:
         if req.path in {"/health", "/login"}:
             return
 
-        cookie = typing.cast("str | None", req.cookies.get("session"))
+        cookie = req.cookies.get("session")
         if cookie is None:
             raise falcon.HTTPUnauthorized()
 
@@ -51,7 +51,7 @@ class LoginResource:
             raise falcon.HTTPUnauthorized()
 
         try:
-            encoded = typing.cast("str", auth_header[len(prefix) :])
+            encoded = auth_header[len(prefix) :]
             decoded_bytes = base64.b64decode(encoded)
             decoded = decoded_bytes.decode()
             username, password = decoded.split(":", 1)

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -26,7 +26,7 @@ class AuthMiddleware:
             return
 
         cookie = req.cookies.get("session")
-        if cookie is None:
+        if not cookie:
             raise falcon.HTTPUnauthorized()
 
         user = self._session.verify_cookie(cookie)

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -18,7 +18,7 @@ async def test_login_sets_cookie() -> None:
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         resp = await ac.post(
             "/login", headers={"Authorization": f"Basic {credentials}"}
@@ -33,7 +33,7 @@ async def test_login_rejects_bad_credentials() -> None:
     credentials = base64.b64encode(b"admin:wrong").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         resp = await ac.post(
             "/login", headers={"Authorization": f"Basic {credentials}"}
@@ -46,7 +46,7 @@ async def test_protected_endpoint_requires_cookie() -> None:
     app = create_app()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         resp = await ac.post("/chat", json={"message": "hi"})
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
@@ -57,7 +57,7 @@ async def test_empty_session_cookie_rejected() -> None:
     app = create_app()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         resp = await ac.post("/chat", json={"message": "hi"}, cookies={"session": ""})
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
@@ -69,18 +69,13 @@ async def test_chat_with_valid_session() -> None:
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         login_resp = await ac.post(
             "/login", headers={"Authorization": f"Basic {credentials}"}
         )
-        session_cookie = login_resp.cookies.get("session")
-        assert session_cookie is not None
-        chat_resp = await ac.post(
-            "/chat",
-            json={"message": "hi"},
-            cookies={"session": session_cookie},
-        )
+        assert "session" in login_resp.cookies
+        chat_resp = await ac.post("/chat", json={"message": "hi"})
     assert chat_resp.status_code == HTTPStatus.NOT_IMPLEMENTED
 
 
@@ -89,7 +84,7 @@ async def test_health_does_not_require_auth() -> None:
     app = create_app()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         resp = await ac.get("/health")
     assert resp.status_code == HTTPStatus.OK
@@ -102,18 +97,14 @@ async def test_expired_session_cookie_rejected() -> None:
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
-        base_url="http://test",
+        base_url="https://test",
     ) as ac:
         with freeze_time() as frozen:
             login_resp = await ac.post(
                 "/login", headers={"Authorization": f"Basic {credentials}"}
             )
             assert login_resp.status_code == HTTPStatus.OK
-            session_cookie = login_resp.cookies["session"]
+            assert "session" in login_resp.cookies
             frozen.tick(delta=dt.timedelta(seconds=2))
-            check_resp = await ac.post(
-                "/chat",
-                json={"message": "hi"},
-                cookies={"session": session_cookie},
-            )
+            check_resp = await ac.post("/chat", json={"message": "hi"})
     assert check_resp.status_code == HTTPStatus.UNAUTHORIZED

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -53,6 +53,17 @@ async def test_protected_endpoint_requires_cookie() -> None:
 
 
 @pytest.mark.asyncio
+async def test_empty_session_cookie_rejected() -> None:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="http://test",
+    ) as ac:
+        resp = await ac.post("/chat", json={"message": "hi"}, cookies={"session": ""})
+    assert resp.status_code == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.asyncio
 async def test_chat_with_valid_session() -> None:
     app = create_app()
     credentials = base64.b64encode(b"admin:adminpass").decode()

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -70,7 +70,7 @@ async def test_chat_with_valid_session() -> None:
             json={"message": "hi"},
             cookies={"session": session_cookie},
         )
-    assert chat_resp.status_code == HTTPStatus.OK
+    assert chat_resp.status_code == HTTPStatus.NOT_IMPLEMENTED
 
 
 @pytest.mark.asyncio

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,6 +9,8 @@ from httpx import ASGITransport, AsyncClient
 if typing.TYPE_CHECKING:
     from falcon import asgi
 
+import base64
+
 from bournemouth.app import create_app
 
 
@@ -17,13 +19,24 @@ def app() -> asgi.App:
     return create_app()
 
 
+async def _login(client: AsyncClient) -> str:
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    resp = await client.post(
+        "/login", headers={"Authorization": f"Basic {credentials}"}
+    )
+    return resp.cookies["session"]
+
+
 @pytest.mark.asyncio
 async def test_chat_not_implemented(app: asgi.App) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="http://test",
     ) as client:
-        resp = await client.post("/chat", json={"message": "hello"})
+        cookie = await _login(client)
+        resp = await client.post(
+            "/chat", json={"message": "hello"}, cookies={"session": cookie}
+        )
     assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
     assert (
         resp.json()["title"]
@@ -37,7 +50,8 @@ async def test_chat_missing_message(app: asgi.App) -> None:
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="http://test",
     ) as client:
-        resp = await client.post("/chat", json={})
+        cookie = await _login(client)
+        resp = await client.post("/chat", json={}, cookies={"session": cookie})
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
@@ -47,7 +61,12 @@ async def test_store_token_not_implemented(app: asgi.App) -> None:
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="http://test",
     ) as client:
-        resp = await client.post("/auth/openrouter-token", json={"api_key": "xyz"})
+        cookie = await _login(client)
+        resp = await client.post(
+            "/auth/openrouter-token",
+            json={"api_key": "xyz"},
+            cookies={"session": cookie},
+        )
     assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
     assert (
         resp.json()["title"]
@@ -61,5 +80,8 @@ async def test_store_token_missing_key(app: asgi.App) -> None:
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="http://test",
     ) as client:
-        resp = await client.post("/auth/openrouter-token", json={})
+        cookie = await _login(client)
+        resp = await client.post(
+            "/auth/openrouter-token", json={}, cookies={"session": cookie}
+        )
     assert resp.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -19,24 +19,23 @@ def app() -> asgi.App:
     return create_app()
 
 
-async def _login(client: AsyncClient) -> str:
+async def _login(client: AsyncClient) -> None:
     credentials = base64.b64encode(b"admin:adminpass").decode()
     resp = await client.post(
         "/login", headers={"Authorization": f"Basic {credentials}"}
     )
-    return resp.cookies["session"]
+    assert resp.status_code == HTTPStatus.OK
+    assert "session" in resp.cookies
 
 
 @pytest.mark.asyncio
 async def test_chat_not_implemented(app: asgi.App) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
-        base_url="http://test",
+        base_url="https://test",
     ) as client:
-        cookie = await _login(client)
-        resp = await client.post(
-            "/chat", json={"message": "hello"}, cookies={"session": cookie}
-        )
+        await _login(client)
+        resp = await client.post("/chat", json={"message": "hello"})
     assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
     assert (
         resp.json()["title"]
@@ -48,10 +47,10 @@ async def test_chat_not_implemented(app: asgi.App) -> None:
 async def test_chat_missing_message(app: asgi.App) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
-        base_url="http://test",
+        base_url="https://test",
     ) as client:
-        cookie = await _login(client)
-        resp = await client.post("/chat", json={}, cookies={"session": cookie})
+        await _login(client)
+        resp = await client.post("/chat", json={})
     assert resp.status_code == HTTPStatus.BAD_REQUEST
 
 
@@ -59,13 +58,12 @@ async def test_chat_missing_message(app: asgi.App) -> None:
 async def test_store_token_not_implemented(app: asgi.App) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
-        base_url="http://test",
+        base_url="https://test",
     ) as client:
-        cookie = await _login(client)
+        await _login(client)
         resp = await client.post(
             "/auth/openrouter-token",
             json={"api_key": "xyz"},
-            cookies={"session": cookie},
         )
     assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
     assert (
@@ -78,10 +76,8 @@ async def test_store_token_not_implemented(app: asgi.App) -> None:
 async def test_store_token_missing_key(app: asgi.App) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
-        base_url="http://test",
+        base_url="https://test",
     ) as client:
-        cookie = await _login(client)
-        resp = await client.post(
-            "/auth/openrouter-token", json={}, cookies={"session": cookie}
-        )
+        await _login(client)
+        resp = await client.post("/auth/openrouter-token", json={})
     assert resp.status_code == HTTPStatus.BAD_REQUEST


### PR DESCRIPTION
## Summary
- remove unnecessary casts in auth middleware
- update tests to handle secure cookies
- expect 501 for chat endpoint

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f948e123483229fb30211846a784a

## Summary by Sourcery

Fix failing authentication tests by adding login helper to set session cookies, updating expected status codes for chat endpoint, and removing unnecessary casts in auth middleware.

Enhancements:
- Remove unnecessary typing.cast calls from auth middleware for cookie retrieval and header decoding.

Tests:
- Introduce _login helper to obtain session cookies and include them in chat and token endpoint tests.
- Update tests to expect HTTP 501 (Not Implemented) for chat endpoint in both resource and integration tests.