### PR TITLE
Set pytest asyncio loop scope

### DIFF
--- a/docs/testing-async-falcon-endpoints.md
+++ b/docs/testing-async-falcon-endpoints.md
@@ -61,6 +61,7 @@ Ini, TOML
 
 \[pytest\]  
 asyncio\_mode \= auto
+asyncio_default_fixture_loop_scope = function
 
 While auto mode can reduce boilerplate, it may obscure the asynchronous nature of a test to readers unfamiliar with the project's configuration, especially in mixed synchronous/asynchronous test suites. The explicit use of @pytest.mark.asyncio, even when auto mode is enabled or if strict mode is the default, enhances code readability and makes the test's asynchronous execution context immediately apparent. This explicitness is generally recommended for clarity, particularly in collaborative projects or when onboarding new team members. The decision between these modes reflects a balance between conciseness and the explicit declaration of asynchronous behavior.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,7 @@ per-file-ignores = {"**/test_*.py" = ["S101"]}
 # Declare the banned `from` imports.
 banned-from = ["typing", "datetime", "collections.abc", "dataclasses"]
 
+[tool.pytest.ini_options]
+# Ensure asyncio fixtures create a new event loop for each test
+asyncio_default_fixture_loop_scope = "function"
+


### PR DESCRIPTION
## Summary
- configure pytest-asyncio fixture loop scope
- document loop scope setting for pytest

## Testing
- `ruff check`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f9a777bd4832283f264c052d8fef2

## Summary by Sourcery

Configure pytest-asyncio to use function-scoped event loops and document the new setting

Enhancements:
- Add asyncio_default_fixture_loop_scope = "function" to pytest config in pyproject.toml to ensure each test gets a fresh event loop

Documentation:
- Update async Falcon testing guide to include the new loop scope setting in pytest configuration