### PR TITLE
Fix deprecation warning in httpx tests

### DIFF
--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -58,8 +58,9 @@ async def test_empty_session_cookie_rejected() -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
+        cookies={"session": ""},
     ) as ac:
-        resp = await ac.post("/chat", json={"message": "hi"}, cookies={"session": ""})
+        resp = await ac.post("/chat", json={"message": "hi"})
     assert resp.status_code == HTTPStatus.UNAUTHORIZED
 
 


### PR DESCRIPTION
## Summary
- fix empty session cookie test to configure cookies on AsyncClient

## Testing
- `ruff format tests/integration/test_auth.py`
- `ruff check tests/integration/test_auth.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9c63897083229a7d17b48a47f459

## Summary by Sourcery

Fix deprecation warning in httpx tests by configuring cookies on AsyncClient instances rather than per request

Bug Fixes:
- Move cookie configuration from post() call to AsyncClient instantiation to resolve the deprecation warning

Tests:
- Set the 'session' cookie on AsyncClient instead of passing cookies to the .post() method in test_empty_session_cookie_rejected