### PR TITLE
Add SQLAlchemy models

### DIFF
--- a/src/bournemouth/models.py
+++ b/src/bournemouth/models.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import datetime as dt
+import enum
+import typing
+import uuid
+
+from sqlalchemy import (
+    JSON,
+    TIMESTAMP,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    LargeBinary,
+    String,
+    Text,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import Uuid
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+
+class AuditEventType(enum.StrEnum):
+    CHAT_REQUEST = enum.auto()
+    CHAT_RESPONSE = enum.auto()
+    KG_UPDATE_ENQUEUED = enum.auto()
+    KG_UPDATE_APPLIED = enum.auto()
+    AUTH = enum.auto()
+    ERROR = enum.auto()
+
+
+class KgChangeType(enum.StrEnum):
+    NODE_CREATED = enum.auto()
+    NODE_UPDATED = enum.auto()
+    REL_CREATED = enum.auto()
+    REL_UPDATED = enum.auto()
+    REL_DEACTIVATED = enum.auto()
+
+
+class MessageRole(enum.StrEnum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+
+
+class UserAccount(Base):
+    __tablename__ = "user_account"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    google_sub: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(255))
+    openrouter_token_enc: Mapped[bytes | None] = mapped_column(LargeBinary)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    last_login_at: Mapped[dt.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint("instr(email, '@') > 1", name="chk_email"),
+    )
+
+    audit_events: Mapped[list[AuditEvent]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    kg_changes: Mapped[list[KgChange]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    conversations: Mapped[list[Conversation]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class AuditEvent(Base):
+    __tablename__ = "audit_event"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("user_account.id", ondelete="CASCADE")
+    )
+    event_type: Mapped[AuditEventType] = mapped_column(
+        Enum(AuditEventType, name="audit_event_type"), nullable=False
+    )
+    http_request_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True))
+    detail: Mapped[str | None] = mapped_column(Text)
+    meta_json: Mapped[typing.Any | None] = mapped_column(JSON)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+
+    user: Mapped[UserAccount] = relationship(back_populates="audit_events")
+
+    __table_args__ = (Index("idx_audit_user_time", "user_id", "created_at"),)
+
+
+class KgChange(Base):
+    __tablename__ = "kg_change"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("user_account.id", ondelete="CASCADE")
+    )
+    change_type: Mapped[KgChangeType] = mapped_column(
+        Enum(KgChangeType, name="kg_change_type"), nullable=False
+    )
+    node_uid: Mapped[str | None] = mapped_column(Text)
+    rel_uid: Mapped[str | None] = mapped_column(Text)
+    cypher_fragment: Mapped[str | None] = mapped_column(Text)
+    diff_json: Mapped[typing.Any | None] = mapped_column(JSON)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+
+    user: Mapped[UserAccount] = relationship(back_populates="kg_changes")
+
+    __table_args__ = (Index("idx_kgchange_user_time", "user_id", "created_at"),)
+
+
+class EncKeyHistory(Base):
+    __tablename__ = "enc_key_history"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    key_id: Mapped[uuid.UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    retired_at: Mapped[dt.datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+
+class Conversation(Base):
+    __tablename__ = "conversation"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("user_account.id", ondelete="CASCADE")
+    )
+    root_message_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True))
+    title: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    forked_from_conv_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True))
+    forked_from_msg_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True))
+
+    user: Mapped[UserAccount] = relationship(back_populates="conversations")
+    messages: Mapped[list[Message]] = relationship(
+        back_populates="conversation", cascade="all, delete-orphan"
+    )
+
+
+class Message(Base):
+    __tablename__ = "message"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    conversation_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("conversation.id", ondelete="CASCADE")
+    )
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("message.id", ondelete="SET NULL")
+    )
+    role: Mapped[MessageRole] = mapped_column(
+        Enum(MessageRole, name="message_role"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    params: Mapped[typing.Any | None] = mapped_column(JSON)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+
+    conversation: Mapped[Conversation] = relationship(back_populates="messages")
+    parent: Mapped[Message] = relationship(remote_side="Message.id")
+
+    __table_args__ = (
+        Index("idx_msg_parent", "parent_id"),
+        Index("idx_msg_convtime", "conversation_id", "created_at"),
+    )

--- a/src/bournemouth/models/__init__.py
+++ b/src/bournemouth/models/__init__.py
@@ -71,7 +71,7 @@ class UserAccount(Base, UuidPKMixin, TimestampMixin):
     )
 
 
-class AuditEvent(Base):
+class AuditEvent(Base, CreatedAtMixin):
     __tablename__ = "audit_event"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -84,11 +84,6 @@ class AuditEvent(Base):
     http_request_id: Mapped[uuid.UUID | None] = mapped_column(Uuid(as_uuid=True))
     detail: Mapped[str | None] = mapped_column(Text)
     meta_json: Mapped[typing.Any | None] = mapped_column(JSON)
-    created_at: Mapped[dt.datetime] = mapped_column(
-        TIMESTAMP(timezone=True),
-        nullable=False,
-        default=lambda: dt.datetime.now(dt.UTC),
-    )
 
     user: Mapped[UserAccount] = relationship(back_populates="audit_events")
 

--- a/src/bournemouth/models/mixins.py
+++ b/src/bournemouth/models/mixins.py
@@ -1,0 +1,42 @@
+import datetime as dt
+import uuid
+
+from sqlalchemy import TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.types import Uuid
+
+__all__ = ["CreatedAtMixin", "TimestampMixin", "UuidPKMixin"]
+
+
+class TimestampMixin:
+    """Add created and updated timestamps."""
+
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+        onupdate=lambda: dt.datetime.now(dt.UTC),
+    )
+
+
+class CreatedAtMixin:
+    """Add created_at timestamp."""
+
+    created_at: Mapped[dt.datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: dt.datetime.now(dt.UTC),
+    )
+
+
+class UuidPKMixin:
+    """Add a UUID primary key."""
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+import uuid
+
+import pytest
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from bournemouth.models import Base, Conversation, Message, UserAccount
+from bournemouth.models import (
+    AuditEvent,
+    Base,
+    Conversation,
+    EncKeyHistory,
+    KgChange,
+    Message,
+    UserAccount,
+)
 
 
 def test_metadata_creates_tables() -> None:
@@ -37,3 +48,38 @@ def test_insert_user_and_message() -> None:
         assert session.get(UserAccount, user.id) is not None
         assert session.get(Conversation, conv.id) is not None
         assert session.get(Message, msg.id) is not None
+
+
+def test_unique_constraints() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        user1 = UserAccount(google_sub="1", email="a@example.com")
+        session.add(user1)
+        session.commit()
+        user2 = UserAccount(google_sub="1", email="b@example.com")
+        session.add(user2)
+        with pytest.raises(sa.exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
+            session.commit()
+        session.rollback()
+        user3 = UserAccount(google_sub="2", email="a@example.com")
+        session.add(user3)
+        with pytest.raises(sa.exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
+            session.commit()
+
+
+def test_persistence_other_models() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        user = UserAccount(google_sub="1", email="a@example.com")
+        session.add(user)
+        session.flush()
+        audit = AuditEvent(user=user, event_type="AUTH")
+        change = KgChange(user=user, change_type="NODE_CREATED")
+        key_hist = EncKeyHistory(key_id=uuid.uuid4())
+        session.add_all([audit, change, key_hist])
+        session.commit()
+        assert session.get(AuditEvent, audit.id) is not None
+        assert session.get(KgChange, change.id) is not None
+        assert session.get(EncKeyHistory, key_hist.id) is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from bournemouth.models import Base, Conversation, Message, UserAccount
+
+
+def test_metadata_creates_tables() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    inspector = sa.inspect(engine)
+    tables = set(inspector.get_table_names())
+    assert {
+        "user_account",
+        "audit_event",
+        "kg_change",
+        "enc_key_history",
+        "conversation",
+        "message",
+    }.issubset(tables)
+
+
+def test_insert_user_and_message() -> None:
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        user = UserAccount(google_sub="123", email="u@example.com")
+        session.add(user)
+        session.flush()
+        conv = Conversation(user=user, title="chat")
+        session.add(conv)
+        session.flush()
+        msg = Message(conversation=conv, role="user", content="hi")
+        session.add(msg)
+        session.commit()
+        assert session.get(UserAccount, user.id) is not None
+        assert session.get(Conversation, conv.id) is not None
+        assert session.get(Message, msg.id) is not None


### PR DESCRIPTION
## Summary
- implement declarative models for the PostgreSQL schema
- verify table creation and basic inserts using SQLite

## Testing
- `ruff check src/bournemouth/models.py`
- `ruff check tests/test_models.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684117340f408322aa3e5abb49b9a3c6

## Summary by Sourcery

Add SQLAlchemy declarative models for core domain entities and accompanying tests to validate schema and basic operations.

New Features:
- Introduce SQLAlchemy ORM models for UserAccount, AuditEvent, KgChange, EncKeyHistory, Conversation, and Message.

Enhancements:
- Define enum types for audit events, KG changes, and message roles, and add mixins for UUID primary keys and timestamp fields, along with relationships, constraints, and indexes to enforce data integrity.

Tests:
- Add tests to verify table creation, unique constraints, and basic CRUD operations using an in-memory SQLite database.