### PR TITLE
Switch tests to pytest-httpx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
   "pytest>=7.0",
   "pytest-asyncio>=0.23",
   "pytest-mock",
+  "pytest-httpx>=0.26",
   "freezegun>=1.4",
 ]
 docs = [

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -1,5 +1,4 @@
 # pyright: reportUnknownArgumentType=false, reportCallIssue=false, reportGeneralTypeIssues=false, reportUntypedBaseClass=false
-
 """Async OpenRouter client built on httpx and msgspec."""
 
 from __future__ import annotations
@@ -8,12 +7,11 @@ import contextlib
 import typing
 from http import HTTPStatus
 
-if typing.TYPE_CHECKING:  # pragma: no cover - imports for type checking
-    import collections.abc as cabc
-    import types
-
 import httpx
 import msgspec
+
+if typing.TYPE_CHECKING:  # pragma: no cover - imports for type checking
+    import collections.abc as cabc
 
 __all__ = [
     "ChatCompletionRequest",
@@ -34,6 +32,7 @@ __all__ = [
     "OpenRouterServerError",
     "OpenRouterTimeoutError",
     "StreamChunk",
+    "TextContentPart",
 ]
 
 
@@ -97,7 +96,6 @@ class ResponseFormat(msgspec.Struct):
 
 
 class ProviderPreferences(msgspec.Struct, array_like=True, forbid_unknown_fields=False):
-    # Placeholder for provider routing fields
     pass
 
 
@@ -159,7 +157,6 @@ class StreamChoice(msgspec.Struct):
     delta: ResponseDelta
     finish_reason: str | None = None
     native_finish_reason: str | None = None
-    logprobs: typing.Any | None = None
 
 
 class UsageStats(msgspec.Struct):
@@ -200,9 +197,8 @@ class OpenRouterErrorResponse(msgspec.Struct, forbid_unknown_fields=False):
     error: OpenRouterAPIErrorDetails
 
 
-# Exception hierarchy
 class OpenRouterClientError(Exception):
-    pass
+    """Base exception for OpenRouter client errors."""
 
 
 class OpenRouterNetworkError(OpenRouterClientError):
@@ -262,6 +258,15 @@ class OpenRouterResponseDataValidationError(OpenRouterDataValidationError):
     pass
 
 
+_STATUS_MAP = {
+    HTTPStatus.UNAUTHORIZED: OpenRouterAuthenticationError,
+    HTTPStatus.PAYMENT_REQUIRED: OpenRouterInsufficientCreditsError,
+    HTTPStatus.FORBIDDEN: OpenRouterPermissionError,
+    HTTPStatus.TOO_MANY_REQUESTS: OpenRouterRateLimitError,
+    HTTPStatus.BAD_REQUEST: OpenRouterInvalidRequestError,
+}
+
+
 def _map_status_to_error(status: int) -> type[OpenRouterAPIError]:
     """Map an HTTP status to a client error type."""
 
@@ -270,21 +275,11 @@ def _map_status_to_error(status: int) -> type[OpenRouterAPIError]:
     except ValueError:
         return OpenRouterAPIError
 
-    match status_enum:
-        case HTTPStatus.UNAUTHORIZED:
-            return OpenRouterAuthenticationError
-        case HTTPStatus.PAYMENT_REQUIRED:
-            return OpenRouterInsufficientCreditsError
-        case HTTPStatus.FORBIDDEN:
-            return OpenRouterPermissionError
-        case HTTPStatus.TOO_MANY_REQUESTS:
-            return OpenRouterRateLimitError
-        case HTTPStatus.BAD_REQUEST:
-            return OpenRouterInvalidRequestError
-        case _ if status_enum >= HTTPStatus.INTERNAL_SERVER_ERROR:
-            return OpenRouterServerError
-        case _:
-            return OpenRouterAPIError
+    if status_enum in _STATUS_MAP:
+        return _STATUS_MAP[status_enum]
+    if status_enum >= HTTPStatus.INTERNAL_SERVER_ERROR:
+        return OpenRouterServerError
+    return OpenRouterAPIError
 
 
 class OpenRouterAsyncClient:
@@ -311,26 +306,35 @@ class OpenRouterAsyncClient:
         self._client: httpx.AsyncClient | None = None
         self._transport = transport
 
-    async def __aenter__(self) -> typing.Self:
-        """Initialize the underlying ``httpx`` client."""
+    async def __aenter__(self) -> "OpenRouterAsyncClient":
+        headers = {"Authorization": f"Bearer {self.api_key}"} | self._user_headers
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=headers,
+            timeout=self.timeout,
+            transport=self._transport,
+        )
+        return self
 
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        """Close the ``httpx`` client and reset internal state."""
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: typing.Any,
+    ) -> None:
+        assert self._client is not None
+        await self._client.aclose()
+        self._client = None
 
-            self._client = None
     async def _decode_error_details(
         self, data: bytes
     ) -> OpenRouterAPIErrorDetails | None:
-        """Return parsed error details if ``data`` is valid JSON."""
-
         try:
             return self._ERR_DECODER.decode(data).error
         except msgspec.DecodeError:
             return None
 
     async def _raise_for_status(self, resp: httpx.Response) -> None:
-        """Raise an API error if the response status indicates failure."""
-
         if resp.status_code < 400:
             return
         raw = await resp.aread()
@@ -343,17 +347,14 @@ class OpenRouterAsyncClient:
         )
 
     async def _decode_response(self, resp: httpx.Response) -> ChatCompletionResponse:
-        """Validate ``resp`` and return the decoded body."""
-
         await self._raise_for_status(resp)
         data = await resp.aread()
         try:
             return self._RESP_DECODER.decode(data)
         except (msgspec.ValidationError, msgspec.DecodeError) as e:
             raise OpenRouterResponseDataValidationError(str(e)) from e
-    async def _post(self, path: str, *, content: bytes) -> httpx.Response:
-        """Send a POST request handling network errors."""
 
+    async def _post(self, path: str, *, content: bytes) -> httpx.Response:
         if not self._client:
             raise RuntimeError("client not initialized; use async with")
         try:
@@ -367,26 +368,42 @@ class OpenRouterAsyncClient:
     async def _stream_post(
         self, path: str, *, content: bytes
     ) -> cabc.AsyncIterator[httpx.Response]:
-        """Yield a streaming response while mapping network errors."""
-
+        if not self._client:
+            raise RuntimeError("client not initialized; use async with")
+        try:
             async with self._client.stream("POST", path, content=content) as resp:
                 yield resp
+        except httpx.TimeoutException as e:
+            raise OpenRouterTimeoutError(str(e)) from e
+        except httpx.RequestError as e:
+            raise OpenRouterNetworkError(str(e)) from e
 
     async def create_chat_completion(
         self, request: ChatCompletionRequest
     ) -> ChatCompletionResponse:
-        """Send a non-streaming completion request."""
         if request.stream:
+            data = msgspec.to_builtins(request)
+            data["stream"] = False
+            request = ChatCompletionRequest(**data)
         try:
             payload = self._ENCODER.encode(request)
         except (msgspec.ValidationError, msgspec.EncodeError) as e:
             raise OpenRouterRequestDataValidationError(str(e)) from e
+        resp = await self._post("/chat/completions", content=payload)
+        return await self._decode_response(resp)
+
+    async def stream_chat_completion(
+        self, request: ChatCompletionRequest
+    ) -> cabc.AsyncIterator[StreamChunk]:
+        if not request.stream:
+            data = msgspec.to_builtins(request)
+            data["stream"] = True
+            request = ChatCompletionRequest(**data)
         try:
             payload = self._ENCODER.encode(request)
         except (msgspec.ValidationError, msgspec.EncodeError) as e:
             raise OpenRouterRequestDataValidationError(str(e)) from e
-                    except (msgspec.ValidationError, msgspec.DecodeError) as e:
-                        raise OpenRouterResponseDataValidationError(
+        async with self._stream_post("/chat/completions", content=payload) as resp:
             await self._raise_for_status(resp)
             async for line in resp.aiter_lines():
                 if not line or line.startswith(":"):
@@ -398,42 +415,6 @@ class OpenRouterAsyncClient:
                     try:
                         yield self._STREAM_DECODER.decode(payload_str)
                     except msgspec.DecodeError as e:
-                        raise OpenRouterAPIError(
+                        raise OpenRouterResponseDataValidationError(
                             f"failed to decode stream chunk: {payload_str}"
                         ) from e
-
-        if not self._client:
-            raise RuntimeError("client not initialized; use async with")
-        payload = self._ENCODER.encode(request)
-        try:
-            async with self._client.stream(
-                "POST", "/chat/completions", content=payload
-            ) as resp:
-                if resp.status_code >= 400:
-                    data = await resp.aread()
-                    try:
-                    except msgspec.DecodeError:
-                        err = None
-                    exc_cls = _map_status_to_error(resp.status_code)
-                    raise exc_cls(
-                        f"API error {resp.status_code}",
-                        status_code=resp.status_code,
-                        error_details=err,
-                    )
-                async for line in resp.aiter_lines():
-                    if not line or line.startswith(":"):
-                        continue
-                    if line.startswith("data: "):
-                        payload_str = line[6:]
-                        if payload_str == "":
-                            break
-                        try:
-                            yield self._STREAM_DECODER.decode(payload_str)
-                        except msgspec.DecodeError as e:
-                            raise OpenRouterAPIError(
-                                f"failed to decode stream chunk: {payload_str}"
-                            ) from e
-        except httpx.TimeoutException as e:
-            raise OpenRouterTimeoutError(str(e)) from e
-        except httpx.RequestError as e:
-            raise OpenRouterNetworkError(str(e)) from e

--- a/tests/test_openrouter_client.py
+++ b/tests/test_openrouter_client.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import typing
 from http import HTTPStatus
 
 import httpx
 import msgspec
 import pytest
+from pytest_httpx import HTTPXMock
 
 from bournemouth import (
     ChatCompletionRequest,
@@ -24,42 +24,33 @@ from bournemouth import (
 from bournemouth.openrouter import TextContentPart
 
 
-class MockTransport(httpx.AsyncBaseTransport):
-    def __init__(
-        self,
-        handler: typing.Callable[[httpx.Request], typing.Awaitable[httpx.Response]],
-    ):
-        self._handler = handler
-
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        return await self._handler(request)
-
-
 @pytest.mark.asyncio
-async def test_create_chat_completion_success() -> None:
+async def test_create_chat_completion_success(httpx_mock: HTTPXMock) -> None:
+    content = {
+        "id": "1",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "openai/gpt-3.5-turbo",
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}}],
+    }
+
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
         assert request.headers["Authorization"] == "Bearer k"
-        data = await request.aread()
-        body = msgspec.json.decode(data)
+        body = msgspec.json.decode(await request.aread())
         assert body["model"] == "openai/gpt-3.5-turbo"
-        content = {
-            "id": "1",
-            "object": "chat.completion",
-            "created": 1,
-            "model": "openai/gpt-3.5-turbo",
-            "choices": [
-                {"index": 0, "message": {"role": "assistant", "content": "hi"}}
-            ],
-        }
         return httpx.Response(200, json=content)
 
-    transport = MockTransport(handler)
+    httpx_mock.add_callback(
+        handler,
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+    )
+
     async with OpenRouterAsyncClient(
         api_key="k",
         default_headers={},
         timeout_config=None,
-        transport=transport,
     ) as client:
         req = ChatCompletionRequest(
             model="openai/gpt-3.5-turbo",
@@ -70,15 +61,15 @@ async def test_create_chat_completion_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_success_status_raises() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.UNAUTHORIZED,
-            json={"error": {"message": "bad", "code": "invalid_key"}},
-        )
+async def test_non_success_status_raises(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.UNAUTHORIZED,
+        json={"error": {"message": "bad", "code": "invalid_key"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="openai/gpt-3.5-turbo",
             messages=[ChatMessage(role="user", content="hi")],
@@ -88,15 +79,15 @@ async def test_non_success_status_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_invalid_request_status_raises() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.BAD_REQUEST,
-            json={"error": {"message": "nope"}},
-        )
+async def test_invalid_request_status_raises(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.BAD_REQUEST,
+        json={"error": {"message": "nope"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="openai/gpt-3.5-turbo",
             messages=[ChatMessage(role="user", content="hi")],
@@ -106,19 +97,21 @@ async def test_invalid_request_status_raises() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_yields_chunks() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        content = (
-            b'data: {"id": "1", "object": "chat.completion.chunk", "created": 1,'
-            b' "model": "m", "choices": [{"index": 0, "delta": {"content": "hi"}}]}\n'
-            b"data: \n"
-        )
-        return httpx.Response(
-            200, content=content, headers={"Content-Type": "text/event-stream"}
-        )
+async def test_streaming_yields_chunks(httpx_mock: HTTPXMock) -> None:
+    content = (
+        b'data: {"id": "1", "object": "chat.completion.chunk", "created": 1,'
+        b' "model": "m", "choices": [{"index": 0, "delta": {"content": "hi"}}]}\n'
+        b"data: \n"
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        headers={"Content-Type": "text/event-stream"},
+        content=content,
+    )
+
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -129,15 +122,15 @@ async def test_streaming_yields_chunks() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_error_status() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.TOO_MANY_REQUESTS,
-            json={"error": {"message": "slow down"}},
-        )
+async def test_streaming_error_status(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.TOO_MANY_REQUESTS,
+        json={"error": {"message": "slow down"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -149,9 +142,11 @@ async def test_streaming_error_status() -> None:
 
 
 @pytest.mark.asyncio
-async def test_client_closes_on_exit() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        content = {
+async def test_client_closes_on_exit(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
             "id": "1",
             "object": "chat.completion",
             "created": 1,
@@ -159,11 +154,10 @@ async def test_client_closes_on_exit() -> None:
             "choices": [
                 {"index": 0, "message": {"role": "assistant", "content": "hi"}}
             ],
-        }
-        return httpx.Response(200, json=content)
+        },
+    )
 
-    transport = MockTransport(handler)
-    client = OpenRouterAsyncClient(api_key="k", transport=transport)
+    client = OpenRouterAsyncClient(api_key="k")
     async with client as c:
         req = ChatCompletionRequest(
             model="m",
@@ -175,12 +169,16 @@ async def test_client_closes_on_exit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_network_error_maps_to_client_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=request)
+async def test_network_error_maps_to_client_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        exception=httpx.ConnectError(
+            "boom", request=httpx.Request("POST", "https://openrouter.ai")
+        ),
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -190,12 +188,16 @@ async def test_network_error_maps_to_client_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_timeout_error_maps_to_timeout_exception() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.TimeoutException("slow", request=request)
+async def test_timeout_error_maps_to_timeout_exception(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_exception(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        exception=httpx.TimeoutException(
+            "slow", request=httpx.Request("POST", "https://openrouter.ai")
+        ),
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -205,7 +207,9 @@ async def test_timeout_error_maps_to_timeout_exception() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_chat_completion_ignores_stream_true() -> None:
+async def test_create_chat_completion_ignores_stream_true(
+    httpx_mock: HTTPXMock,
+) -> None:
     content = {
         "id": "1",
         "object": "chat.completion",
@@ -215,13 +219,17 @@ async def test_create_chat_completion_ignores_stream_true() -> None:
     }
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        data = await request.aread()
-        body = msgspec.json.decode(data)
+        body = msgspec.json.decode(await request.aread())
         assert body["stream"] is False
         return httpx.Response(200, json=content)
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    httpx_mock.add_callback(
+        handler,
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+    )
+
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -232,7 +240,7 @@ async def test_create_chat_completion_ignores_stream_true() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_chat_completion_sets_stream_true() -> None:
+async def test_stream_chat_completion_sets_stream_true(httpx_mock: HTTPXMock) -> None:
     content = (
         b'data: {"id": "1", "object": "chat.completion.chunk", "created": 1, '
         b'"model": "m", "choices": [{"index": 0, "delta": {"content": "hi"}}]}\n'
@@ -240,8 +248,7 @@ async def test_stream_chat_completion_sets_stream_true() -> None:
     )
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        data = await request.aread()
-        body = msgspec.json.decode(data)
+        body = msgspec.json.decode(await request.aread())
         assert body["stream"] is True
         return httpx.Response(
             200,
@@ -249,8 +256,13 @@ async def test_stream_chat_completion_sets_stream_true() -> None:
             headers={"Content-Type": "text/event-stream"},
         )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    httpx_mock.add_callback(
+        handler,
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+    )
+
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -261,15 +273,15 @@ async def test_stream_chat_completion_sets_stream_true() -> None:
 
 
 @pytest.mark.asyncio
-async def test_insufficient_credits_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.PAYMENT_REQUIRED,
-            json={"error": {"message": "pay up"}},
-        )
+async def test_insufficient_credits_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.PAYMENT_REQUIRED,
+        json={"error": {"message": "pay up"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -279,15 +291,15 @@ async def test_insufficient_credits_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_permission_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.FORBIDDEN,
-            json={"error": {"message": "no"}},
-        )
+async def test_permission_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.FORBIDDEN,
+        json={"error": {"message": "no"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -297,15 +309,15 @@ async def test_permission_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_server_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            HTTPStatus.INTERNAL_SERVER_ERROR,
-            json={"error": {"message": "boom"}},
-        )
+async def test_server_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        json={"error": {"message": "boom"}},
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -315,12 +327,14 @@ async def test_server_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_invalid_json_raises_validation_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, content=b"{bad json}")
+async def test_invalid_json_raises_validation_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        content=b"{bad json}",
+    )
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],
@@ -330,17 +344,19 @@ async def test_invalid_json_raises_validation_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stream_invalid_chunk_raises_validation_error() -> None:
-    async def handler(request: httpx.Request) -> httpx.Response:
-        content = b"data: {bad json}\n"
-        return httpx.Response(
-            200,
-            content=content,
-            headers={"Content-Type": "text/event-stream"},
-        )
+async def test_stream_invalid_chunk_raises_validation_error(
+    httpx_mock: HTTPXMock,
+) -> None:
+    content = b"data: {bad json}\n"
 
-    transport = MockTransport(handler)
-    async with OpenRouterAsyncClient(api_key="k", transport=transport) as client:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        headers={"Content-Type": "text/event-stream"},
+        content=content,
+    )
+
+    async with OpenRouterAsyncClient(api_key="k") as client:
         req = ChatCompletionRequest(
             model="m",
             messages=[ChatMessage(role="user", content="hi")],


### PR DESCRIPTION
## Summary
- rewrite OpenRouter client with clean context manager
- use pytest-httpx for OpenRouter client tests
- ensure compatibility with newer dependency versions

## Testing
- `ruff format src/bournemouth/openrouter.py tests/test_openrouter_client.py pyproject.toml`
- `ruff check tests/test_openrouter_client.py src/bournemouth/openrouter.py pyproject.toml`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441756b5ac8322a2da9537c2be2a8a