### PR TITLE
Add session fixture and API key validation tests

### DIFF
--- a/docs/chat-endpoint-openapi.yaml
+++ b/docs/chat-endpoint-openapi.yaml
@@ -1,0 +1,89 @@
+openapi: 3.1.0
+info:
+  title: Bournemouth Chat API
+  version: '0.1'
+paths:
+  /chat:
+    post:
+      summary: Chat with an assistant model
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  answer:
+                    type: string
+                required:
+                  - answer
+        '400':
+          $ref: '#/components/responses/Problem'
+  /auth/openrouter-token:
+    post:
+      summary: Store the user's OpenRouter API key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                api_key:
+                  type: string
+              required:
+                - api_key
+      responses:
+        '204':
+          description: Stored
+        '400':
+          $ref: '#/components/responses/Problem'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+      required:
+        - title
+    ChatRequest:
+      type: object
+      properties:
+        message:
+          type: string
+        model:
+          type: string
+        history:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+      required:
+        - message
+    Message:
+      type: object
+      properties:
+        role:
+          type: string
+          enum: [system, user, assistant, tool]
+        content:
+          type: string
+      required:
+        - role
+        - content
+  responses:
+    Problem:
+      description: Problem details
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProblemDetails'

--- a/src/bournemouth/errors.py
+++ b/src/bournemouth/errors.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+import typing
+from http import HTTPStatus
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from falcon import HTTPError, Request, Response
+
+__all__ = ["handle_http_error", "handle_unexpected_error"]
+
+
+async def handle_http_error(
+    req: Request,
+    resp: Response,
+    exc: HTTPError,
+    params: dict[str, typing.Any],
+) -> None:
+    """Serialize :class:`falcon.HTTPError` exceptions as JSON."""
+    resp.status = exc.status
+    resp.media = {"title": exc.title, "description": exc.description}
+
+
+async def handle_unexpected_error(
+    req: Request,
+    resp: Response,
+    exc: BaseException,
+    params: dict[str, typing.Any],
+) -> None:
+    """Handle uncaught exceptions with a generic JSON payload."""
+    logging.exception("unhandled error", exc_info=exc)
+    resp.status = HTTPStatus.INTERNAL_SERVER_ERROR
+    resp.media = {
+        "title": (
+            f"{HTTPStatus.INTERNAL_SERVER_ERROR.value} "
+            f"{HTTPStatus.INTERNAL_SERVER_ERROR.phrase}"
+        ),
+        "description": "An unexpected error occurred.",
+    }

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -33,6 +33,7 @@ __all__ = [
     "OpenRouterResponseDataValidationError",
     "OpenRouterServerError",
     "OpenRouterTimeoutError",
+    "Role",
     "StreamChunk",
     "TextContentPart",
 ]
@@ -40,6 +41,9 @@ __all__ = [
 
 DEFAULT_BASE_URL = "https://openrouter.ai/api/v1/"
 CHAT_COMPLETIONS_PATH = "/chat/completions"
+
+# Reusable annotation for message roles used by OpenRouter
+Role = typing.Literal["system", "user", "assistant", "tool"]
 
 
 class ImageUrl(msgspec.Struct, array_like=True):
@@ -61,7 +65,7 @@ ContentPart = TextContentPart | ImageContentPart
 
 
 class ChatMessage(msgspec.Struct):
-    role: typing.Literal["system", "user", "assistant", "tool"]
+    role: Role
     content: str | list[ContentPart]
     name: str | None = None
     tool_call_id: str | None = None

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import dataclasses
+import os
+import typing
+
+if typing.TYPE_CHECKING:
+    import httpx
+
+from .openrouter import (
+    DEFAULT_BASE_URL,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    OpenRouterAPIError,
+    OpenRouterAsyncClient,
+    OpenRouterNetworkError,
+    OpenRouterServerError,
+    OpenRouterTimeoutError,
+)
+
+DEFAULT_MODEL = "deepseek/deepseek-chat-v3-0324:free"
+
+
+@dataclasses.dataclass(slots=True)
+class OpenRouterService:
+    """Wrapper around :class:`OpenRouterAsyncClient` configuration."""
+
+    default_model: str = DEFAULT_MODEL
+    base_url: str = DEFAULT_BASE_URL
+    timeout_config: httpx.Timeout | None = None
+
+    @classmethod
+    def from_env(cls) -> OpenRouterService:
+        model = os.getenv("OPENROUTER_MODEL") or DEFAULT_MODEL
+        base_url = os.getenv("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL
+        return cls(default_model=model, base_url=base_url)
+
+    async def chat_completion(
+        self,
+        api_key: str,
+        messages: list[ChatMessage],
+        *,
+        model: str | None = None,
+    ) -> ChatCompletionResponse:
+        request = ChatCompletionRequest(
+            model=model or self.default_model,
+            messages=messages,
+        )
+        async with OpenRouterAsyncClient(
+            api_key=api_key,
+            base_url=self.base_url,
+            timeout_config=self.timeout_config,
+        ) as client:
+            return await client.create_chat_completion(request)
+
+
+class OpenRouterServiceError(Exception):
+    """Raised when the OpenRouter service fails."""
+
+
+class OpenRouterServiceTimeoutError(OpenRouterServiceError):
+    pass
+
+
+class OpenRouterServiceBadGatewayError(OpenRouterServiceError):
+    pass
+
+
+async def chat_with_service(
+    service: OpenRouterService,
+    api_key: str,
+    messages: list[ChatMessage],
+    *,
+    model: str | None = None,
+) -> ChatCompletionResponse:
+    try:
+        return await service.chat_completion(api_key, messages, model=model)
+    except OpenRouterTimeoutError as exc:
+        raise OpenRouterServiceTimeoutError(str(exc)) from None
+    except (OpenRouterNetworkError, OpenRouterServerError, OpenRouterAPIError) as exc:
+        raise OpenRouterServiceBadGatewayError(str(exc)) from None

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -2,48 +2,128 @@
 
 from __future__ import annotations
 
-import dataclasses
 import typing
 
 import falcon
+import msgspec
+from sqlalchemy import select, update
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import UserAccount
+from .openrouter import ChatMessage, Role
+from .openrouter_service import (
+    OpenRouterService,
+    OpenRouterServiceBadGatewayError,
+    OpenRouterServiceTimeoutError,
+    chat_with_service,
+)
 
 
-@dataclasses.dataclass(slots=True)
-class ChatRequest:
+class ChatRequest(msgspec.Struct):
     """Request body for the chat endpoint."""
 
     message: str
     history: list[dict[str, typing.Any]] | None = None
+    model: str | None = None
 
 
 class ChatResource:
     """Handle chat requests."""
 
-    async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
-        data = await req.get_media()
-        if not data or "message" not in data:
-            raise falcon.HTTPBadRequest(description="`message` field required")
+    def __init__(
+        self,
+        service: OpenRouterService,
+        session_factory: typing.Callable[[], AsyncSession],
+    ) -> None:
+        self._service = service
+        self._session_factory = session_factory
 
-        # TODO(pmcintosh): plug in RAG and LLM call
-        # https://github.com/example/repo/issues/1
-        raise falcon.HTTPNotImplemented(
-            description="This endpoint is not yet implemented."
-        )
+    async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
+        raw = await typing.cast("typing.Awaitable[bytes]", req.bounded_stream.read())
+        try:
+            data = msgspec.json.decode(raw)
+        except msgspec.DecodeError:
+            raise falcon.HTTPBadRequest(description="invalid JSON") from None
+
+        match data:
+            case {"message": str(msg), **extra}:
+                pass
+            case _:
+                raise falcon.HTTPBadRequest(description="`message` field required")
+        history: list[ChatMessage] = []
+        if isinstance(extra.get("history"), list):
+            valid_roles = typing.get_args(Role)
+            for item in extra["history"]:
+                match item:
+                    case {"role": role, "content": str(content)} if role in valid_roles:
+                        history.append(
+                            ChatMessage(
+                                role=typing.cast("Role", role),
+                                content=content,
+                            )
+                        )
+                    case _:
+                        raise falcon.HTTPBadRequest(description="invalid history item")
+
+        history.append(ChatMessage(role="user", content=msg))
+
+        model = typing.cast("str | None", extra.get("model"))
+
+        async with self._session_factory() as session:
+            stmt = select(UserAccount.openrouter_token_enc).where(
+                UserAccount.google_sub == typing.cast("str", req.context["user"])
+            )
+            result = await session.execute(stmt)
+            token = typing.cast("bytes | str | None", result.scalar_one_or_none())
+        if not token:
+            raise falcon.HTTPBadRequest(description="missing OpenRouter token")
+
+        api_key = token.decode() if isinstance(token, bytes) else token
+
+        try:
+            completion = await chat_with_service(
+                self._service,
+                api_key,
+                history,
+                model=model,
+            )
+        except OpenRouterServiceTimeoutError:
+            raise falcon.HTTPGatewayTimeout() from None
+        except OpenRouterServiceBadGatewayError as exc:
+            raise falcon.HTTPBadGateway(description=str(exc)) from None  # pyright: ignore[reportUnknownArgumentType]
+
+        if not completion.choices:
+            raise falcon.HTTPBadGateway(description="OpenRouter returned no choices")
+
+        answer = completion.choices[0].message.content or ""
+        resp.media = {"answer": answer}
 
 
 class OpenRouterTokenResource:
     """Store user's OpenRouter API token."""
 
+    def __init__(self, session_factory: typing.Callable[[], AsyncSession]) -> None:
+        self._session_factory = session_factory
+
     async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
         data = await req.get_media()
-        if not data or "api_key" not in data:
+        api_key = data.get("api_key") if isinstance(data, dict) else None
+        if not isinstance(api_key, str):
             raise falcon.HTTPBadRequest(description="`api_key` field required")
 
-        # TODO(pmcintosh): persist the token for the authenticated user
-        # https://github.com/example/repo/issues/2
-        raise falcon.HTTPNotImplemented(
-            description="This endpoint is not yet implemented."
-        )
+        async with self._session_factory() as session:
+            stmt = (
+                update(UserAccount)
+                .where(
+                    UserAccount.google_sub == typing.cast("str", req.context["user"])
+                )
+                .values(openrouter_token_enc=api_key.encode())
+            )
+            await session.execute(stmt)
+            await session.commit()
+        resp.status = falcon.HTTP_NO_CONTENT
 
 
 class HealthResource:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,37 @@
 import sys
+import typing
 from pathlib import Path
 
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from bournemouth.models import Base, UserAccount
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+
+@pytest_asyncio.fixture()
+async def db_session_factory() -> typing.AsyncIterator[typing.Callable[[], AsyncSession]]:
+    """Create an in-memory SQLite ``AsyncSession`` factory."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with engine.begin() as conn, session_factory() as session:
+        await conn.run_sync(Base.metadata.create_all)
+        async with session.begin():
+            session.add(
+                UserAccount(
+                    google_sub="admin",
+                    email="admin@example.com",
+                    openrouter_token_enc=b"k",
+                )
+            )
+
+    def factory() -> AsyncSession:
+        return session_factory()
+
+    yield factory
+    await engine.dispose()

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -9,12 +9,22 @@ import pytest
 from freezegun import freeze_time
 from httpx import ASGITransport, AsyncClient
 
+if typing.TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from bournemouth.app import create_app
+
+type SessionFactory = typing.Callable[[], AsyncSession]
 
 
 @pytest.mark.asyncio
-async def test_login_sets_cookie() -> None:
-    app = create_app()
+async def test_login_sets_cookie(
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
@@ -28,8 +38,10 @@ async def test_login_sets_cookie() -> None:
 
 
 @pytest.mark.asyncio
-async def test_login_rejects_bad_credentials() -> None:
-    app = create_app()
+async def test_login_rejects_bad_credentials(
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:wrong").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
@@ -42,8 +54,10 @@ async def test_login_rejects_bad_credentials() -> None:
 
 
 @pytest.mark.asyncio
-async def test_protected_endpoint_requires_cookie() -> None:
-    app = create_app()
+async def test_protected_endpoint_requires_cookie(
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
         base_url="https://test",
@@ -53,8 +67,10 @@ async def test_protected_endpoint_requires_cookie() -> None:
 
 
 @pytest.mark.asyncio
-async def test_empty_session_cookie_rejected() -> None:
-    app = create_app()
+async def test_empty_session_cookie_rejected(
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -65,9 +81,26 @@ async def test_empty_session_cookie_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_chat_with_valid_session() -> None:
-    app = create_app()
+async def test_chat_with_valid_session(
+    httpx_mock: HTTPXMock,
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:adminpass").decode()
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "deepseek/deepseek-chat-v3-0324:free",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "hi"}}
+            ],
+        },
+    )
+
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
         base_url="https://test",
@@ -77,12 +110,14 @@ async def test_chat_with_valid_session() -> None:
         )
         assert "session" in login_resp.cookies
         chat_resp = await ac.post("/chat", json={"message": "hi"})
-    assert chat_resp.status_code == HTTPStatus.NOT_IMPLEMENTED
+    assert chat_resp.status_code == HTTPStatus.OK
 
 
 @pytest.mark.asyncio
-async def test_health_does_not_require_auth() -> None:
-    app = create_app()
+async def test_health_does_not_require_auth(
+    db_session_factory: SessionFactory,
+) -> None:
+    app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
         base_url="https://test",
@@ -92,9 +127,11 @@ async def test_health_does_not_require_auth() -> None:
 
 
 @pytest.mark.asyncio
-async def test_expired_session_cookie_rejected() -> None:
+async def test_expired_session_cookie_rejected(
+    db_session_factory: SessionFactory,
+) -> None:
     """Requests with expired session cookies should return 401."""
-    app = create_app(session_timeout=1)
+    app = create_app(session_timeout=1, db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -8,15 +8,23 @@ from httpx import ASGITransport, AsyncClient
 
 if typing.TYPE_CHECKING:
     from falcon import asgi
+    from pytest_httpx import HTTPXMock
+
 
 import base64
 
+from sqlalchemy import select
+
+if typing.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
 from bournemouth.app import create_app
+from bournemouth.models import UserAccount
 
 
 @pytest.fixture()
-def app() -> asgi.App:
-    return create_app()
+def app(db_session_factory: typing.Callable[[], AsyncSession]) -> asgi.App:
+    return create_app(db_session_factory=db_session_factory)
 
 
 async def _login(client: AsyncClient) -> None:
@@ -28,19 +36,56 @@ async def _login(client: AsyncClient) -> None:
     assert "session" in resp.cookies
 
 
+pytest_plugins = ["pytest_httpx"]
+
+
 @pytest.mark.asyncio
-async def test_chat_not_implemented(app: asgi.App) -> None:
+async def test_chat_returns_answer(app: asgi.App, httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "deepseek/deepseek-chat-v3-0324:free",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "hi"}}
+            ],
+        },
+    )
+
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
     ) as client:
         await _login(client)
         resp = await client.post("/chat", json={"message": "hello"})
-    assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
-    assert (
-        resp.json()["title"]
-        == f"{HTTPStatus.NOT_IMPLEMENTED.value} {HTTPStatus.NOT_IMPLEMENTED.phrase}"
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["answer"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_chat_handles_empty_choices(app: asgi.App, httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "deepseek/deepseek-chat-v3-0324:free",
+            "choices": [],
+        },
     )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        await _login(client)
+        resp = await client.post("/chat", json={"message": "hello"})
+    assert resp.status_code == HTTPStatus.BAD_GATEWAY
 
 
 @pytest.mark.asyncio
@@ -55,7 +100,9 @@ async def test_chat_missing_message(app: asgi.App) -> None:
 
 
 @pytest.mark.asyncio
-async def test_store_token_not_implemented(app: asgi.App) -> None:
+async def test_store_token(
+    app: asgi.App, db_session_factory: typing.Callable[[], AsyncSession]
+) -> None:
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -65,11 +112,15 @@ async def test_store_token_not_implemented(app: asgi.App) -> None:
             "/auth/openrouter-token",
             json={"api_key": "xyz"},
         )
-    assert resp.status_code == HTTPStatus.NOT_IMPLEMENTED
-    assert (
-        resp.json()["title"]
-        == f"{HTTPStatus.NOT_IMPLEMENTED.value} {HTTPStatus.NOT_IMPLEMENTED.phrase}"
-    )
+    assert resp.status_code == HTTPStatus.NO_CONTENT
+    async with db_session_factory() as session:
+        result = await session.execute(
+            select(UserAccount.openrouter_token_enc).where(
+                UserAccount.google_sub == "admin"
+            )
+        )
+        stored = result.scalar_one()
+        assert stored == b"xyz"
 
 
 @pytest.mark.asyncio
@@ -81,3 +132,20 @@ async def test_store_token_missing_key(app: asgi.App) -> None:
         await _login(client)
         resp = await client.post("/auth/openrouter-token", json={})
     assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("api_key", [123, True, None])
+async def test_store_token_non_string(
+    app: asgi.App,
+    db_session_factory: typing.Callable[[], AsyncSession],
+    api_key: typing.Any,
+) -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        await _login(client)
+        resp = await client.post("/auth/openrouter-token", json={"api_key": api_key})
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.json()["description"] == "`api_key` field required"


### PR DESCRIPTION
## Summary
- centralize `db_session_factory` fixture in `tests/conftest.py`
- guard against empty completions in `ChatResource`
- test `/auth/openrouter-token` with non-string `api_key`
- check behaviour when OpenRouter returns no choices

## Testing
- `ruff check src/bournemouth/app.py src/bournemouth/resources.py tests/test_resources.py tests/integration/test_auth.py`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d08408f083228c290ec6dace05b7

## Summary by Sourcery

Implement and test full chat and token management flow by adding service layer, endpoint logic, error handling, and documentation

New Features:
- Implement chat endpoint with JSON parsing, history validation, session token retrieval, OpenRouterService integration, and empty completion guard
- Implement openrouter-token endpoint to persist API key with validation against non-string inputs
- Add OpenRouterService and chat_with_service wrapper to handle OpenRouter API calls with error mapping
- Introduce global JSON error handlers for HTTP and unexpected errors

Enhancements:
- Refactor app factory for dependency injection of DB session factory and OpenRouterService
- Centralize database session fixture in tests and update tests to use it

Documentation:
- Add OpenAPI specification for chat and token endpoints

Tests:
- Add unit tests for chat endpoint success, empty-choice handling, and missing message validation
- Add tests for token storage behavior including non-string API key validation
- Update integration tests to use shared DB session fixture and HTTPX mocks for OpenRouter calls