### PR TITLE
Consolidate pytest_httpx plugin

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -34,9 +34,6 @@ async def _login(client: AsyncClient) -> None:
     assert "session" in resp.cookies
 
 
-pytest_plugins = ["pytest_httpx"]
-
-
 @pytest.mark.asyncio
 async def test_chat_returns_answer(app: asgi.App, httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(


### PR DESCRIPTION
## Summary
- remove duplicate `pytest_plugins` declaration from `tests/test_resources.py`

## Testing
- `ruff format tests/test_resources.py --quiet`
- `ruff check tests/test_resources.py --quiet`
- `pyright tests/test_resources.py`
- `pytest -q tests/test_resources.py tests/integration/test_auth.py`

------
https://chatgpt.com/codex/tasks/task_e_684581d6cf748322a5dd8544bda6a6d2