### PR TITLE
Reuse OpenRouterAsyncClient instances

### DIFF
--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import dataclasses
 import os
 import typing
@@ -23,6 +24,13 @@ from .openrouter import (
 DEFAULT_MODEL = "deepseek/deepseek-chat-v3-0324:free"
 
 
+def _make_set_event() -> asyncio.Event:
+    """Return an already-set event for initial state."""
+    event = asyncio.Event()
+    event.set()
+    return event
+
+
 @dataclasses.dataclass(slots=True)
 class OpenRouterService:
     """Wrapper around :class:`OpenRouterAsyncClient` configuration."""
@@ -30,22 +38,23 @@ class OpenRouterService:
     default_model: str = DEFAULT_MODEL
     base_url: str = DEFAULT_BASE_URL
     timeout_config: httpx.Timeout | None = None
+    max_clients: int = 10
     _clients: dict[str, OpenRouterAsyncClient] = dataclasses.field(
         default_factory=dict, init=False, repr=False
     )
     _locks: dict[str, asyncio.Lock] = dataclasses.field(
         default_factory=dict, init=False, repr=False
     )
+    _client_order: collections.deque[str] = dataclasses.field(
+        default_factory=collections.deque, init=False, repr=False
+    )
+    _cache_lock: asyncio.Lock = dataclasses.field(
+        default_factory=asyncio.Lock, init=False, repr=False
+    )
     _inflight: int = dataclasses.field(default=0, init=False, repr=False)
     _inflight_lock: asyncio.Lock = dataclasses.field(
         default_factory=asyncio.Lock, init=False, repr=False
     )
-
-    @staticmethod
-    def _make_set_event() -> asyncio.Event:
-        event = asyncio.Event()
-        event.set()
-        return event
 
     _no_inflight: asyncio.Event = dataclasses.field(
         default_factory=_make_set_event,
@@ -62,27 +71,38 @@ class OpenRouterService:
 
     async def _get_client(self, api_key: str) -> OpenRouterAsyncClient:
         """Return a cached client, instantiating it once per API key."""
-        lock = self._locks.get(api_key)
-        if lock is None:
-            lock = asyncio.Lock()
-            lock = self._locks.setdefault(api_key, lock)
-        async with lock:
+        async with self._cache_lock:
+            lock = self._locks.get(api_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[api_key] = lock
+        async with lock, self._cache_lock:
             client = self._clients.get(api_key)
-            if client is None:
-                client = OpenRouterAsyncClient(
-                    api_key=api_key,
-                    base_url=self.base_url,
-                    timeout_config=self.timeout_config,
-                )
-                await client.__aenter__()
-                self._clients[api_key] = client
+            if client is not None:
+                if api_key in self._client_order:
+                    self._client_order.remove(api_key)
+                self._client_order.append(api_key)
+                return client
+            if len(self._clients) >= self.max_clients:
+                evict = self._client_order.popleft()
+                stale = self._clients.pop(evict)
+                await stale.__aexit__(None, None, None)
+                self._locks.pop(evict, None)
+            client = OpenRouterAsyncClient(
+                api_key=api_key,
+                base_url=self.base_url,
+                timeout_config=self.timeout_config,
+            )
+            await client.__aenter__()
+            self._clients[api_key] = client
+            self._client_order.append(api_key)
             return client
 
     async def aclose(self) -> None:
-        if self._closing:
-            await self._no_inflight.wait()
-            return
         async with self._inflight_lock:
+            if self._closing:
+                await self._no_inflight.wait()
+                return
             self._closing = True
             if self._inflight == 0:
                 self._no_inflight.set()
@@ -91,6 +111,19 @@ class OpenRouterService:
             await client.__aexit__(None, None, None)
         self._clients.clear()
         self._locks.clear()
+        self._client_order.clear()
+        self._closing = False
+        self._no_inflight.set()
+
+    async def remove_client(self, api_key: str) -> None:
+        """Close and remove a cached client."""
+        async with self._cache_lock:
+            client = self._clients.pop(api_key, None)
+            self._locks.pop(api_key, None)
+            if api_key in self._client_order:
+                self._client_order.remove(api_key)
+        if client is not None:
+            await client.__aexit__(None, None, None)
 
     async def chat_completion(
         self,

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -29,12 +29,32 @@ class OpenRouterService:
     default_model: str = DEFAULT_MODEL
     base_url: str = DEFAULT_BASE_URL
     timeout_config: httpx.Timeout | None = None
+    _clients: dict[str, OpenRouterAsyncClient] = dataclasses.field(
+        default_factory=dict, init=False, repr=False
+    )
 
     @classmethod
     def from_env(cls) -> OpenRouterService:
         model = os.getenv("OPENROUTER_MODEL") or DEFAULT_MODEL
         base_url = os.getenv("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL
         return cls(default_model=model, base_url=base_url)
+
+    async def _get_client(self, api_key: str) -> OpenRouterAsyncClient:
+        client = self._clients.get(api_key)
+        if client is None:
+            client = OpenRouterAsyncClient(
+                api_key=api_key,
+                base_url=self.base_url,
+                timeout_config=self.timeout_config,
+            )
+            await client.__aenter__()
+            self._clients[api_key] = client
+        return client
+
+    async def aclose(self) -> None:
+        for client in self._clients.values():
+            await client.__aexit__(None, None, None)
+        self._clients.clear()
 
     async def chat_completion(
         self,
@@ -47,12 +67,8 @@ class OpenRouterService:
             model=model or self.default_model,
             messages=messages,
         )
-        async with OpenRouterAsyncClient(
-            api_key=api_key,
-            base_url=self.base_url,
-            timeout_config=self.timeout_config,
-        ) as client:
-            return await client.create_chat_completion(request)
+        client = await self._get_client(api_key)
+        return await client.create_chat_completion(request)
 
 
 class OpenRouterServiceError(Exception):

--- a/tests/test_openrouter_service.py
+++ b/tests/test_openrouter_service.py
@@ -32,6 +32,7 @@ DummyClient.creations = 0
 
 @pytest.mark.asyncio
 async def test_reuses_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    DummyClient.creations = 0
     monkeypatch.setattr(
         "bournemouth.openrouter_service.OpenRouterAsyncClient", DummyClient
     )

--- a/tests/test_openrouter_service.py
+++ b/tests/test_openrouter_service.py
@@ -1,0 +1,42 @@
+import typing
+
+import pytest
+
+from bournemouth.openrouter import ChatMessage
+from bournemouth.openrouter_service import OpenRouterService
+
+
+class DummyClient:
+    def __init__(
+        self, *, api_key: str, base_url: str, timeout_config: typing.Any
+    ) -> None:
+        DummyClient.creations += 1
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: typing.Any,
+    ) -> None:
+        return
+
+    async def create_chat_completion(self, request: typing.Any) -> str:
+        return "ok"
+
+
+DummyClient.creations = 0
+
+
+@pytest.mark.asyncio
+async def test_reuses_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "bournemouth.openrouter_service.OpenRouterAsyncClient", DummyClient
+    )
+    service = OpenRouterService()
+    msg = [ChatMessage(role="user", content="hi")]
+    await service.chat_completion("k", msg)
+    await service.chat_completion("k", msg)
+    assert DummyClient.creations == 1


### PR DESCRIPTION
## Summary
- keep a pool of OpenRouterAsyncClient instances in OpenRouterService
- add aclose() for explicit cleanup
- test that service reuses clients when called twice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684581ef02f08322bf31aa41ca88c1e9

## Summary by Sourcery

Pool and reuse OpenRouterAsyncClient instances with eviction policy, add explicit close and client removal methods, and update chat_completion to leverage the client cache.

New Features:
- Cache and reuse OpenRouterAsyncClient instances per API key with LRU eviction when exceeding max_clients
- Add aclose() method to gracefully close all clients after in-flight operations complete
- Provide remove_client() method to close and remove a specific cached client

Enhancements:
- Track in-flight requests to prevent closing while operations are pending
- Modify chat_completion to use the pooled clients instead of creating a new client each call

Tests:
- Add tests for client reuse in sequential and concurrent calls
- Add tests ensuring aclose() waits for ongoing requests and allows reuse after closing
- Add tests for remove_client() behavior closing only the specified client