### PR TITLE
Use msgspec structs for HTTP body parsing

### DIFF
--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -27,7 +27,7 @@ def _msgspec_loads_json_robust(content: bytes | str) -> typing.Any:
 
 
 json_handler = falcon.media.JSONHandler(
-    dumps=_ENCODER.encode,
+    dumps=lambda obj: _ENCODER.encode(obj).decode("utf-8"),
     loads=_msgspec_loads_json_robust,
 )
 

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -15,11 +15,12 @@ _ENCODER = msgspec.json.Encoder()
 _DECODER = msgspec.json.Decoder()
 
 
-def _msgspec_loads_json_robust(content: typing.Any) -> typing.Any:
+def _msgspec_loads_json_robust(content: bytes | str) -> typing.Any:
     try:
         return _DECODER.decode(content)
     except msgspec.DecodeError as ex:  # pragma: no cover - integration tested
         raise falcon.MediaMalformedError(
+            falcon.MEDIA_JSON,
             title="Invalid JSON",
             description=f"The JSON payload is malformed: {ex!s}",
         ) from ex
@@ -47,7 +48,7 @@ class AsyncMsgspecMiddleware:
             return
         media_data = await req.get_media()
         validated = msgspec.convert(media_data, schema, strict=True)
-        params[schema.__name__.lower()] = validated
+        params["body"] = validated
 
 
 async def handle_msgspec_validation_error(

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import typing
+
+import falcon
+import msgspec
+
+__all__ = [
+    "AsyncMsgspecMiddleware",
+    "handle_msgspec_validation_error",
+    "json_handler",
+]
+
+_ENCODER = msgspec.json.Encoder()
+_DECODER = msgspec.json.Decoder()
+
+
+def _msgspec_loads_json_robust(content: typing.Any) -> typing.Any:
+    try:
+        return _DECODER.decode(content)
+    except msgspec.DecodeError as ex:  # pragma: no cover - integration tested
+        raise falcon.MediaMalformedError(
+            title="Invalid JSON",
+            description=f"The JSON payload is malformed: {ex!s}",
+        ) from ex
+
+
+json_handler = falcon.media.JSONHandler(
+    dumps=_ENCODER.encode,
+    loads=_msgspec_loads_json_robust,
+)
+
+
+class AsyncMsgspecMiddleware:
+    async def process_resource(
+        self,
+        req: falcon.Request,
+        resp: falcon.Response,
+        resource: object,
+        params: dict[str, typing.Any],
+    ) -> None:
+        schema_attr = f"{req.method.upper()}_SCHEMA"
+        schema = getattr(resource, schema_attr, None)
+        if schema is None:
+            return
+        if not isinstance(schema, type) or not issubclass(schema, msgspec.Struct):
+            return
+        media_data = await req.get_media()
+        validated = msgspec.convert(media_data, schema, strict=True)
+        params[schema.__name__.lower()] = validated
+
+
+async def handle_msgspec_validation_error(
+    req: falcon.Request,
+    resp: falcon.Response,
+    ex: msgspec.ValidationError,
+    params: dict[str, typing.Any],
+) -> None:
+    raise falcon.HTTPUnprocessableEntity(
+        title="Validation Error",
+        description=str(ex),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,9 @@ pytest_plugins = ["pytest_httpx"]
 
 
 @pytest_asyncio.fixture()
-async def db_session_factory() -> typing.AsyncIterator[typing.Callable[[], AsyncSession]]:
+async def db_session_factory() -> typing.AsyncIterator[
+    typing.Callable[[], AsyncSession]
+]:
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
     async with engine.begin() as conn, async_session_factory() as session:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -71,7 +71,7 @@ async def test_chat_missing_message(app: asgi.App) -> None:
     ) as client:
         await _login(client)
         resp = await client.post("/chat", json={})
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
@@ -106,7 +106,7 @@ async def test_store_token_missing_key(app: asgi.App) -> None:
     ) as client:
         await _login(client)
         resp = await client.post("/auth/openrouter-token", json={})
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio
@@ -117,7 +117,7 @@ async def test_store_token_non_string(app: asgi.App) -> None:
     ) as client:
         await _login(client)
         resp = await client.post("/auth/openrouter-token", json={"api_key": 1})
-    assert resp.status_code == HTTPStatus.BAD_REQUEST
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `msgspec_support` module with JSON handler and middleware
- integrate middleware and error handling in `create_app`
- use `ChatRequest` and `TokenRequest` structs for request parsing
- update tests for validation errors

## Testing
- `ruff check src/bournemouth/msgspec_support.py src/bournemouth/app.py src/bournemouth/resources.py tests/conftest.py tests/test_resources.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845828dff38832284044f49aa0f4fff

## Summary by Sourcery

Use msgspec for structured JSON parsing and validation by adding middleware, handlers, and schema structs, simplifying request processing in resources and standardizing error responses

New Features:
- Add msgspec_support module providing JSON handler, AsyncMsgspecMiddleware, and validation error handler

Enhancements:
- Define HttpMessage, ChatRequest, and TokenRequest as msgspec.Structs for request schemas and wire them into resources via POST_SCHEMA

Tests:
- Update tests to expect HTTP 422 Unprocessable Entity on validation errors