### PR TITLE
Add AsyncAPI spec for WebSocket chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,5 @@ Testing strategies and additional guides live in the `docs/` directory, includin
   for asynchronous database access.
 - [`docs/embedding-with-hf-tei.md`](docs/embedding-with-hf-tei.md)
   for generating embeddings with Hugging Face TEI.
+- [`docs/websocket-chat-api-asyncapi.yaml`](docs/websocket-chat-api-asyncapi.yaml)
+  for the WebSocket chat API specification.

--- a/docs/websocket-chat-api-asyncapi.yaml
+++ b/docs/websocket-chat-api-asyncapi.yaml
@@ -1,0 +1,76 @@
+asyncapi: '2.6.0'
+info:
+  title: Bournemouth Chat WebSocket API
+  version: '0.1'
+servers:
+  local:
+    url: ws://localhost:8000/chat
+    protocol: ws
+    description: Local development server
+channels:
+  chat:
+    description: WebSocket channel for chat messages
+    publish:
+      summary: Send a chat request
+      operationId: sendChat
+      message:
+        $ref: '#/components/messages/ChatRequest'
+    subscribe:
+      summary: Receive streaming chat responses
+      operationId: receiveChat
+      message:
+        $ref: '#/components/messages/ChatResponse'
+components:
+  messages:
+    ChatRequest:
+      name: ChatRequest
+      title: Chat request
+      payload:
+        $ref: '#/components/schemas/ChatRequest'
+    ChatResponse:
+      name: ChatResponse
+      title: Chat response fragment
+      payload:
+        $ref: '#/components/schemas/ChatResponse'
+  schemas:
+    ChatRequest:
+      type: object
+      properties:
+        transaction_id:
+          type: string
+          description: Correlates request with streamed responses
+        message:
+          type: string
+        model:
+          type: string
+        history:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+      required:
+        - transaction_id
+        - message
+    ChatResponse:
+      type: object
+      properties:
+        transaction_id:
+          type: string
+        fragment:
+          type: string
+        finished:
+          type: boolean
+          description: true when this is the last fragment in the stream
+      required:
+        - transaction_id
+        - fragment
+    Message:
+      type: object
+      properties:
+        role:
+          type: string
+          enum: [system, user, assistant, tool]
+        content:
+          type: string
+      required:
+        - role
+        - content


### PR DESCRIPTION
## Summary
- design WebSocket API specification using AsyncAPI
- cross-link the new spec from the README

## Testing
- `markdownlint README.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_e_684600a063b883229a25657ae26471cb

## Summary by Sourcery

Add a machine-readable AsyncAPI specification for the WebSocket chat API and link it in the project README

New Features:
- Introduce an AsyncAPI YAML file defining the WebSocket chat channels, messages, and schemas

Documentation:
- Add a README entry referencing the new WebSocket chat API spec