### PR TITLE
Implement websocket chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "itsdangerous>=2.1",
   "httpx>=0.27",
   "msgspec>=0.19,<0.20",
+  "aiosqlite>=0.21.0",
 ]
 
 [dependency-groups]

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -17,6 +17,7 @@ from .auth import AuthMiddleware, LoginResource
 from .errors import handle_http_error, handle_unexpected_error
 from .msgspec_support import (
     AsyncMsgspecMiddleware,
+    MsgspecWebSocketMiddleware,
     handle_msgspec_validation_error,
     json_handler,
 )
@@ -60,7 +61,11 @@ def create_app(
     user = login_user or os.getenv("LOGIN_USER", "admin")
     password = login_password or os.getenv("LOGIN_PASSWORD", "adminpass")
     session = SessionManager(secret, timeout)
-    middleware = [AuthMiddleware(session), AsyncMsgspecMiddleware()]
+    middleware = [
+        AuthMiddleware(session),
+        AsyncMsgspecMiddleware(),
+        MsgspecWebSocketMiddleware(),
+    ]
     app = asgi.App(middleware=middleware)
     app.add_error_handler(falcon.HTTPError, handle_http_error)
     app.add_error_handler(Exception, handle_unexpected_error)

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -35,6 +35,22 @@ class AuthMiddleware:
 
         req.context["user"] = user
 
+    async def process_request_ws(
+        self, req: falcon.Request, ws: falcon.asgi.WebSocket
+    ) -> None:
+        if req.path in {"/health", "/login"}:
+            return
+
+        cookie = req.cookies.get("session")
+        if not cookie:
+            raise falcon.HTTPUnauthorized()
+
+        user = self._session.verify_cookie(cookie)
+        if user is None:
+            raise falcon.HTTPUnauthorized()
+
+        req.context["user"] = user
+
 
 class LoginResource:
     """Authenticate via Basic Auth and set a signed session cookie."""

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -7,6 +7,8 @@ import msgspec
 
 __all__ = [
     "AsyncMsgspecMiddleware",
+    "MsgspecProcessor",
+    "MsgspecWebSocketMiddleware",
     "handle_msgspec_validation_error",
     "json_handler",
 ]
@@ -67,3 +69,50 @@ async def handle_msgspec_validation_error(
         title="Validation Error",
         description=str(ex),
     )
+
+
+class MsgspecProcessor:
+    def __init__(
+        self,
+        encoder: msgspec.json.Encoder,
+        decoder_factory: typing.Callable[
+            [type[typing.Any]], msgspec.json.Decoder[typing.Any]
+        ],
+    ) -> None:
+        self._encoder = encoder
+        self._decoder_factory = decoder_factory
+
+    async def receive_struct(
+        self, ws: falcon.asgi.WebSocket, expected_type: type[typing.Any]
+    ) -> typing.Any:
+        raw_data = await ws.receive_text()
+        decoder = self._decoder_factory(expected_type)
+        return decoder.decode(raw_data)  # pyright: ignore[reportUnknownArgumentType]
+
+    async def send_struct(
+        self, ws: falcon.asgi.WebSocket, message: msgspec.Struct
+    ) -> None:
+        raw = self._encoder.encode(message)
+        await ws.send_text(raw.decode("utf-8"))
+
+
+class MsgspecWebSocketMiddleware:
+    def __init__(self, protocol: str = "json") -> None:
+        if protocol != "json":
+            raise ValueError(f"Unsupported msgspec protocol: {protocol}")
+        self._encoder = msgspec.json.Encoder()
+
+        def factory(t: type[typing.Any]) -> msgspec.json.Decoder[typing.Any]:
+            return msgspec.json.Decoder(t)
+
+        self._decoder_factory = factory
+
+    async def process_resource_ws(
+        self,
+        req: falcon.asgi.Request,
+        ws: falcon.asgi.WebSocket,
+        resource: object,
+        params: dict[str, typing.Any],
+    ) -> None:
+        processor = MsgspecProcessor(self._encoder, self._decoder_factory)
+        req.context.msgspec_processor = processor

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -11,13 +11,16 @@ from sqlalchemy import select, update
 if typing.TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from .msgspec_support import MsgspecProcessor
+
 from .models import UserAccount
-from .openrouter import ChatMessage, Role
+from .openrouter import ChatMessage, Role, StreamChoice
 from .openrouter_service import (
     OpenRouterService,
     OpenRouterServiceBadGatewayError,
     OpenRouterServiceTimeoutError,
     chat_with_service,
+    stream_chat_with_service,
 )
 
 
@@ -34,12 +37,31 @@ class ChatRequest(msgspec.Struct):
     model: str | None = None
 
 
+class ChatWsRequest(msgspec.Struct):
+    transaction_id: str
+    message: str
+    model: str | None = None
+    history: list[HttpMessage] | None = None
+
+
+class ChatWsResponse(msgspec.Struct):
+    transaction_id: str
+    fragment: str
+    finished: bool = False
+
+
 class TokenRequest(msgspec.Struct):
     api_key: str
 
 
 class ChatResource:
-    """Handle chat requests."""
+    """Handle chat requests.
+
+    The WebSocket API currently processes messages sequentially, meaning
+    only one chat stream is handled at a time. Once the initial workflow is
+    proven, we'll add multiplexing to support concurrent streams over a
+    single connection.
+    """
 
     POST_SCHEMA = ChatRequest
 
@@ -50,6 +72,65 @@ class ChatResource:
     ) -> None:
         self._service = service
         self._session_factory = session_factory
+
+    def _build_history(self, request: ChatWsRequest) -> list[ChatMessage]:
+        hist = request.history or []
+        history = [ChatMessage(role=m.role, content=m.content) for m in hist]
+        history.append(ChatMessage(role="user", content=request.message))
+        return history
+
+    async def _get_api_key(self, user: str) -> str | None:
+        async with self._session_factory() as session:
+            stmt = select(UserAccount.openrouter_token_enc).where(
+                UserAccount.google_sub == user
+            )
+            result = await session.execute(stmt)
+            token: bytes | str | None = typing.cast(
+                "bytes | str | None", result.scalar_one_or_none()
+            )
+        if token is None:
+            return None
+        return token.decode() if isinstance(token, bytes) else token
+
+    async def _stream_chat(
+        self,
+        ws: falcon.asgi.WebSocket,
+        processor: MsgspecProcessor,
+        transaction_id: str,
+        api_key: str,
+        history: list[ChatMessage],
+        model: str | None,
+    ) -> None:
+        try:
+            async for chunk in stream_chat_with_service(
+                self._service,
+                api_key,
+                history,
+                model=model,
+            ):
+                choice: StreamChoice = chunk.choices[0]
+                if choice.delta.content:
+                    await processor.send_struct(
+                        ws,  # pyright: ignore[reportUnknownArgumentType]
+                        ChatWsResponse(
+                            transaction_id=transaction_id,
+                            fragment=choice.delta.content,
+                        ),
+                    )
+                if choice.finish_reason is not None:
+                    await processor.send_struct(
+                        ws,  # pyright: ignore[reportUnknownArgumentType]
+                        ChatWsResponse(
+                            transaction_id=transaction_id,
+                            fragment="",
+                            finished=True,
+                        ),
+                    )
+                    break
+        except OpenRouterServiceTimeoutError:
+            await ws.close(code=1011)
+        except OpenRouterServiceBadGatewayError:
+            await ws.close(code=1011)
 
     async def on_post(
         self,
@@ -93,6 +174,44 @@ class ChatResource:
 
         answer = completion.choices[0].message.content or ""
         resp.media = {"answer": answer}
+
+    async def on_websocket(
+        self, req: falcon.asgi.Request, ws: falcon.asgi.WebSocket
+    ) -> None:
+        processor = typing.cast("MsgspecProcessor", req.context.msgspec_processor)
+        await ws.accept()
+        try:
+            while True:
+                request = typing.cast(
+                    "ChatWsRequest",
+                    await processor.receive_struct(
+                        ws,  # pyright: ignore[reportUnknownArgumentType]
+                        ChatWsRequest,
+                    ),
+                )
+                history = self._build_history(request)
+                user = typing.cast("str", req.context["user"])
+                api_key = await self._get_api_key(user)
+                if api_key is None:
+                    await processor.send_struct(
+                        ws,  # pyright: ignore[reportUnknownArgumentType]
+                        ChatWsResponse(
+                            transaction_id=request.transaction_id,
+                            fragment="missing OpenRouter token",
+                            finished=True,
+                        ),
+                    )
+                    continue
+                await self._stream_chat(
+                    ws,  # pyright: ignore[reportUnknownArgumentType]
+                    processor,
+                    request.transaction_id,
+                    api_key,
+                    history,
+                    request.model,
+                )
+        except falcon.WebSocketDisconnected:
+            return
 
 
 class OpenRouterTokenResource:

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -1,0 +1,69 @@
+import base64
+import typing
+
+import msgspec
+import pytest
+from falcon import asgi, testing
+from httpx import ASGITransport, AsyncClient
+from pytest_httpx import HTTPXMock
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bournemouth.app import create_app
+from bournemouth.resources import ChatWsRequest, ChatWsResponse
+
+type SessionFactory = typing.Callable[[], AsyncSession]
+
+
+@pytest.fixture()
+def app(db_session_factory: SessionFactory) -> asgi.App:
+    return create_app(db_session_factory=db_session_factory)
+
+
+@pytest.fixture()
+def conductor(app: asgi.App) -> testing.ASGIConductor:
+    return testing.ASGIConductor(app)
+
+
+async def _login(client: AsyncClient) -> str:
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    resp = await client.post(
+        "/login", headers={"Authorization": f"Basic {credentials}"}
+    )
+    assert resp.status_code == 200
+    return typing.cast("str", resp.cookies.get("session"))
+
+
+@pytest.mark.asyncio
+async def test_websocket_streams_chat(
+    app: asgi.App, conductor: testing.ASGIConductor, httpx_mock: HTTPXMock
+) -> None:
+    content = (
+        b'data: {"id": "1", "object": "chat.completion.chunk", '
+        b'"created": 1, "model": "m", "choices": [{"index": 0, '
+        b'"delta": {"content": "hi"}}]}\n'
+        b'data: {"id": "1", "object": "chat.completion.chunk", '
+        b'"created": 1, "model": "m", "choices": [{"index": 0, '
+        b'"delta": {}, "finish_reason": "stop"}}]}\n'
+        b"data: \n"
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        headers={"Content-Type": "text/event-stream"},
+        content=content,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        cookie = await _login(client)
+
+    headers = {"cookie": f"session={cookie}"}
+    async with conductor.simulate_ws("/chat", headers=headers) as ws:
+        req = ChatWsRequest(transaction_id="t1", message="hi")
+        await ws.send_text(msgspec.json.encode(req).decode())
+        first = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        assert first.fragment == "hi"
+        last = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        assert last.finished is True

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 2
 requires-python = ">=3.13"
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +66,7 @@ name = "bournemouth"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "falcon" },
     { name = "httpx" },
@@ -79,6 +92,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "falcon", specifier = ">=3.1" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary
- implement MsgspecWebSocketMiddleware and processor for typed messaging
- add websocket chat handler using the new middleware
- stream completions via OpenRouter service
- create websocket test exercising streaming chat
- clarify websocket handler is single-threaded for now
- install aiosqlite for async SQLite engine

## Testing
- `ruff check .`
- `pyright`
- `pytest -q` *(tests passed before interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684633008ff883229745306d8c67e74b

## Summary by Sourcery

Implement a WebSocket-based chat endpoint that streams AI-generated responses, introduce middleware and processor for typed message handling, extend the service and authentication layers for WebSocket support, and add an end-to-end test and async database dependency.

New Features:
- Implement WebSocket chat handler with typed request/response messages and streaming completions via OpenRouter
- Add MsgspecWebSocketMiddleware and MsgspecProcessor for structured WebSocket messaging
- Support streaming chat completions in OpenRouterService with new streaming methods

Enhancements:
- Extend AuthMiddleware to authenticate WebSocket connections
- Clarify ChatResource is single-threaded and add helpers for building chat history and API key retrieval

Build:
- Add aiosqlite as an async SQLite engine dependency

Tests:
- Add integration test for WebSocket streaming chat using HTTPXMock