### PR TITLE
Implement websocket chat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "itsdangerous>=2.1",
   "httpx>=0.27",
   "msgspec>=0.19,<0.20",
+  "aiosqlite>=0.21.0",
 ]
 
 [dependency-groups]

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -17,6 +17,7 @@ from .auth import AuthMiddleware, LoginResource
 from .errors import handle_http_error, handle_unexpected_error
 from .msgspec_support import (
     AsyncMsgspecMiddleware,
+    MsgspecWebSocketMiddleware,
     handle_msgspec_validation_error,
     json_handler,
 )
@@ -60,7 +61,11 @@ def create_app(
     user = login_user or os.getenv("LOGIN_USER", "admin")
     password = login_password or os.getenv("LOGIN_PASSWORD", "adminpass")
     session = SessionManager(secret, timeout)
-    middleware = [AuthMiddleware(session), AsyncMsgspecMiddleware()]
+    middleware = [
+        AuthMiddleware(session),
+        AsyncMsgspecMiddleware(),
+        MsgspecWebSocketMiddleware(),
+    ]
     app = asgi.App(middleware=middleware)
     app.add_error_handler(falcon.HTTPError, handle_http_error)
     app.add_error_handler(Exception, handle_unexpected_error)

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -35,6 +35,22 @@ class AuthMiddleware:
 
         req.context["user"] = user
 
+    async def process_request_ws(
+        self, req: falcon.Request, ws: falcon.asgi.WebSocket
+    ) -> None:
+        if req.path in {"/health", "/login"}:
+            return
+
+        cookie = req.cookies.get("session")
+        if not cookie:
+            raise falcon.HTTPUnauthorized()
+
+        user = self._session.verify_cookie(cookie)
+        if user is None:
+            raise falcon.HTTPUnauthorized()
+
+        req.context["user"] = user
+
 
 class LoginResource:
     """Authenticate via Basic Auth and set a signed session cookie."""

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -7,6 +7,7 @@ import msgspec
 
 __all__ = [
     "AsyncMsgspecMiddleware",
+    "MsgspecWebSocketMiddleware",
     "handle_msgspec_validation_error",
     "json_handler",
 ]
@@ -67,3 +68,21 @@ async def handle_msgspec_validation_error(
         title="Validation Error",
         description=str(ex),
     )
+
+
+class MsgspecWebSocketMiddleware:
+    def __init__(self, protocol: str = "json") -> None:
+        if protocol != "json":
+            raise ValueError(f"Unsupported msgspec protocol: {protocol}")
+        self.encoder = msgspec.json.Encoder()
+        self.decoder_cls = msgspec.json.Decoder
+
+    async def process_resource_ws(
+        self,
+        req: falcon.asgi.Request,
+        ws: falcon.asgi.WebSocket,
+        resource: object,
+        params: dict[str, typing.Any],
+    ) -> None:
+        req.context.msgspec_encoder = self.encoder
+        req.context.msgspec_decoder = self.decoder_cls

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -1,0 +1,69 @@
+import base64
+import typing
+
+import msgspec
+import pytest
+from falcon import asgi, testing
+from httpx import ASGITransport, AsyncClient
+from pytest_httpx import HTTPXMock
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bournemouth.app import create_app
+from bournemouth.resources import ChatWsRequest, ChatWsResponse
+
+type SessionFactory = typing.Callable[[], AsyncSession]
+
+
+@pytest.fixture()
+def app(db_session_factory: SessionFactory) -> asgi.App:
+    return create_app(db_session_factory=db_session_factory)
+
+
+@pytest.fixture()
+def conductor(app: asgi.App) -> testing.ASGIConductor:
+    return testing.ASGIConductor(app)
+
+
+async def _login(client: AsyncClient) -> str:
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    resp = await client.post(
+        "/login", headers={"Authorization": f"Basic {credentials}"}
+    )
+    assert resp.status_code == 200
+    return typing.cast("str", resp.cookies.get("session"))
+
+
+@pytest.mark.asyncio
+async def test_websocket_streams_chat(
+    app: asgi.App, conductor: testing.ASGIConductor, httpx_mock: HTTPXMock
+) -> None:
+    content = (
+        b'data: {"id": "1", "object": "chat.completion.chunk", '
+        b'"created": 1, "model": "m", "choices": [{"index": 0, '
+        b'"delta": {"content": "hi"}}]}\n'
+        b'data: {"id": "1", "object": "chat.completion.chunk", '
+        b'"created": 1, "model": "m", "choices": [{"index": 0, '
+        b'"delta": {}, "finish_reason": "stop"}}]}\n'
+        b"data: \n"
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        headers={"Content-Type": "text/event-stream"},
+        content=content,
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        cookie = await _login(client)
+
+    headers = {"cookie": f"session={cookie}"}
+    async with conductor.simulate_ws("/chat", headers=headers) as ws:
+        req = ChatWsRequest(transaction_id="t1", message="hi")
+        await ws.send_text(msgspec.json.encode(req).decode())
+        first = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        assert first.fragment == "hi"
+        last = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        assert last.finished is True

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 2
 requires-python = ">=3.13"
 
 [[package]]
+name = "aiosqlite"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/7d/8bca2bf9a247c2c5dfeec1d7a5f40db6518f88d314b8bca9da29670d2671/aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3", size = 13454, upload-time = "2025-02-03T07:30:16.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/10/6c25ed6de94c49f88a91fa5018cb4c0f3625f31d5be9f771ebe5cc7cd506/aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0", size = 15792, upload-time = "2025-02-03T07:30:13.6Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -54,6 +66,7 @@ name = "bournemouth"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "falcon" },
     { name = "httpx" },
@@ -79,6 +92,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "falcon", specifier = ">=3.1" },
     { name = "httpx", specifier = ">=0.27" },


### PR DESCRIPTION
## Summary
- implement MsgspecWebSocketMiddleware and processor for typed messaging
- add websocket chat handler using the new middleware
- stream completions via OpenRouter service
- create websocket test exercising streaming chat
- clarify websocket handler is single-threaded for now
- install aiosqlite for async SQLite engine

------
https://chatgpt.com/codex/tasks/task_e_684633008ff883229745306d8c67e74b