### PR TITLE
Simplify msgspec websocket middleware

### DIFF
--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -85,4 +85,4 @@ class MsgspecWebSocketMiddleware:
         params: dict[str, typing.Any],
     ) -> None:
         req.context.msgspec_encoder = self.encoder
-        req.context.msgspec_decoder = self.decoder_cls
+        req.context.msgspec_decoder_cls = self.decoder_cls

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -178,7 +178,8 @@ class ChatResource:
     ) -> None:
         encoder = typing.cast("msgspec.json.Encoder", req.context.msgspec_encoder)
         decoder_cls = typing.cast(
-            "type[msgspec.json.Decoder[ChatWsRequest]]", req.context.msgspec_decoder
+            "type[msgspec.json.Decoder[ChatWsRequest]]",
+            req.context.msgspec_decoder_cls,
         )
         decoder = decoder_cls(ChatWsRequest)
         await ws.accept()


### PR DESCRIPTION
## Summary
- remove `MsgspecProcessor` indirection
- store msgspec encoder and decoder directly on request context
- adjust resources to use the new injection model
- update documentation

## Testing
- `ruff format --check src tests`
- `ruff check src tests`
- `pyright`
- `pytest -q`
- `markdownlint docs/using-falcon-websockets-with-msgspec-structs.md` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846b26b7bcc83229fdac019cebdbd9b

## Summary by Sourcery

Simplify the Msgspec WebSocket middleware by removing the MsgspecProcessor abstraction and directly injecting the msgspec encoder and decoder into the request context, updating resource handlers and documentation accordingly.

Enhancements:
- Remove the MsgspecProcessor class and related indirection in the middleware
- Inject msgspec_encoder and msgspec_decoder directly into req.context instead of using a processor
- Refactor resource implementations to use req.context.msgspec_encoder/msgspec_decoder for serialization and deserialization

Documentation:
- Update documentation examples to reflect the new encoder/decoder injection model and remove references to MsgspecProcessor

Chores:
- Remove dead code and imports related to MsgspecProcessor