### PR TITLE
Fix ty issues

### DIFF
--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -8,6 +8,7 @@ import typing
 from http import HTTPStatus
 
 import falcon
+import falcon.asgi
 
 if typing.TYPE_CHECKING:
     from .session import SessionManager

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import typing
 
 import falcon
+import falcon.asgi
+import falcon.media
 import msgspec
+from msgspec import json as msgspec_json
 
 __all__ = [
     "AsyncMsgspecMiddleware",
@@ -12,8 +15,8 @@ __all__ = [
     "json_handler",
 ]
 
-_ENCODER = msgspec.json.Encoder()
-_DECODER = msgspec.json.Decoder()
+_ENCODER = msgspec_json.Encoder()
+_DECODER = msgspec_json.Decoder()
 
 
 def _msgspec_loads_json_robust(content: bytes | str) -> typing.Any:
@@ -74,8 +77,8 @@ class MsgspecWebSocketMiddleware:
     def __init__(self, protocol: str = "json") -> None:
         if protocol != "json":
             raise ValueError(f"Unsupported msgspec protocol: {protocol}")
-        self.encoder = msgspec.json.Encoder()
-        self.decoder_cls = msgspec.json.Decoder
+        self.encoder = msgspec_json.Encoder()
+        self.decoder_cls = msgspec_json.Decoder
 
     async def process_resource_ws(
         self,

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -9,6 +9,7 @@ from http import HTTPStatus
 
 import httpx
 import msgspec
+from msgspec import json as msgspec_json
 
 if typing.TYPE_CHECKING:  # pragma: no cover - imports for type checking
     import collections.abc as cabc
@@ -295,10 +296,10 @@ def _map_status_to_error(status: int) -> type[OpenRouterAPIError]:
 class OpenRouterAsyncClient:
     """Asynchronous client for OpenRouter's completions API."""
 
-    _ENCODER = msgspec.json.Encoder()
-    _RESP_DECODER = msgspec.json.Decoder(ChatCompletionResponse)
-    _STREAM_DECODER = msgspec.json.Decoder(StreamChunk)
-    _ERR_DECODER = msgspec.json.Decoder(OpenRouterErrorResponse)
+    _ENCODER = msgspec_json.Encoder()
+    _RESP_DECODER = msgspec_json.Decoder(ChatCompletionResponse)
+    _STREAM_DECODER = msgspec_json.Decoder(StreamChunk)
+    _ERR_DECODER = msgspec_json.Decoder(OpenRouterErrorResponse)
 
     def __init__(
         self,

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -7,7 +7,9 @@ import contextlib
 import typing
 
 import falcon
+import falcon.asgi
 import msgspec
+from msgspec import json as msgspec_json
 from sqlalchemy import select, update
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -93,8 +95,8 @@ class ChatResource:
     async def _stream_chat(
         self,
         ws: falcon.asgi.WebSocket,
-        encoder: msgspec.json.Encoder,
-        send_lock: asyncio.Lock,]
+        encoder: msgspec_json.Encoder,
+        send_lock: asyncio.Lock,
         transaction_id: str,
         api_key: str,
         history: list[ChatMessage],
@@ -181,9 +183,9 @@ class ChatResource:
     async def on_websocket(
         self, req: falcon.asgi.Request, ws: falcon.asgi.WebSocket
     ) -> None:
-        encoder = typing.cast("msgspec.json.Encoder", req.context.msgspec_encoder)
+        encoder = typing.cast("msgspec_json.Encoder", req.context.msgspec_encoder)
         decoder_cls = typing.cast(
-            "type[msgspec.json.Decoder[ChatWsRequest]]",
+            "type[msgspec_json.Decoder[ChatWsRequest]]",
             req.context.msgspec_decoder_cls,
         )
         decoder = decoder_cls(ChatWsRequest)

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -2,10 +2,10 @@ import asyncio
 import base64
 import typing
 
-import msgspec
 import pytest
 from falcon import asgi, testing
 from httpx import ASGITransport, AsyncClient
+from msgspec import json as msgspec_json
 from pytest_httpx import HTTPXMock
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -64,10 +64,10 @@ async def test_websocket_streams_chat(
     headers = {"cookie": f"session={cookie}"}
     async with conductor.simulate_ws("/chat", headers=headers) as ws:
         req = ChatWsRequest(transaction_id="t1", message="hi")
-        await ws.send_text(msgspec.json.encode(req).decode())
-        first = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        await ws.send_text(msgspec_json.encode(req).decode())
+        first = msgspec_json.decode(await ws.receive_text(), type=ChatWsResponse)
         assert first.fragment == "hi"
-        last = msgspec.json.decode(await ws.receive_text(), type=ChatWsResponse)
+        last = msgspec_json.decode(await ws.receive_text(), type=ChatWsResponse)
         assert last.finished is True
 
 
@@ -144,25 +144,25 @@ async def test_websocket_multiplexes_requests(
     headers = {"cookie": f"session={cookie}"}
     async with conductor.simulate_ws("/chat", headers=headers) as ws:
         await ws.send_text(
-            msgspec.json.encode(
+            msgspec_json.encode(
                 ChatWsRequest(transaction_id="t1", message="a")
             ).decode()
         )
         await ws.send_text(
-            msgspec.json.encode(
+            msgspec_json.encode(
                 ChatWsRequest(transaction_id="t2", message="b")
             ).decode()
         )
-        first = msgspec.json.decode(
+        first = msgspec_json.decode(
             await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
         )
-        second = msgspec.json.decode(
+        second = msgspec_json.decode(
             await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
         )
-        third = msgspec.json.decode(
+        third = msgspec_json.decode(
             await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
         )
-        fourth = msgspec.json.decode(
+        fourth = msgspec_json.decode(
             await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
 from sqlalchemy.orm import Session
 
 from bournemouth.models import (
@@ -59,12 +60,12 @@ def test_unique_constraints() -> None:
         session.commit()
         user2 = UserAccount(google_sub="1", email="b@example.com")
         session.add(user2)
-        with pytest.raises(sa.exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
+        with pytest.raises(sa_exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
             session.commit()
         session.rollback()
         user3 = UserAccount(google_sub="2", email="a@example.com")
         session.add(user3)
-        with pytest.raises(sa.exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
+        with pytest.raises(sa_exc.IntegrityError):  # pyright: ignore[reportUnknownArgumentType]
             session.commit()
 
 

--- a/tests/test_openrouter_client.py
+++ b/tests/test_openrouter_client.py
@@ -4,8 +4,8 @@ import typing
 from http import HTTPStatus
 
 import httpx
-import msgspec
 import pytest
+from msgspec import json as msgspec_json
 
 if typing.TYPE_CHECKING:  # pragma: no cover - fixtures only
     import collections.abc as cabc
@@ -72,7 +72,7 @@ async def test_create_chat_completion_success(
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
         assert request.headers["Authorization"] == "Bearer k"
-        body = msgspec.json.decode(await request.aread())
+        body = msgspec_json.decode(await request.aread())
         assert body["model"] == "openai/gpt-3.5-turbo"
         return httpx.Response(200, json=content)
 
@@ -250,7 +250,7 @@ async def test_create_chat_completion_ignores_stream_true(
     }
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        body = msgspec.json.decode(await request.aread())
+        body = msgspec_json.decode(await request.aread())
         assert body["stream"] is False
         return httpx.Response(200, json=content)
 
@@ -277,7 +277,7 @@ async def test_stream_chat_completion_sets_stream_true(
     )
 
     async def handler(request: httpx.Request) -> httpx.Response:
-        body = msgspec.json.decode(await request.aread())
+        body = msgspec_json.decode(await request.aread())
         assert body["stream"] is True
         return httpx.Response(
             200,

--- a/tests/test_openrouter_service.py
+++ b/tests/test_openrouter_service.py
@@ -8,6 +8,8 @@ from bournemouth.openrouter_service import OpenRouterService
 
 
 class DummyClient:
+    creations: int = 0
+
     def __init__(
         self, *, api_key: str, base_url: str, timeout_config: typing.Any
     ) -> None:
@@ -27,9 +29,6 @@ class DummyClient:
     async def create_chat_completion(self, request: typing.Any) -> str:
         await asyncio.sleep(0)
         return "ok"
-
-
-DummyClient.creations = 0
 
 
 @pytest.mark.asyncio
@@ -105,6 +104,8 @@ async def test_can_reuse_after_aclose(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.asyncio
 async def test_remove_client(monkeypatch: pytest.MonkeyPatch) -> None:
     class ClosingClient(DummyClient):
+        closes: int = 0
+
         async def __aexit__(
             self,
             exc_type: type[BaseException] | None,


### PR DESCRIPTION
## Summary
- import Falcon ASGI and msgspec.json modules explicitly
- update tests to use new msgspec_json alias
- configure integrity error checks using sa_exc

## Testing
- `uv venv`
- `uv sync`
- `ty check`
- `pytest -q` *(failed: KeyboardInterrupt after tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_6846dfed51ac8322bf8335af5cd442f5

## Summary by Sourcery

Standardize JSON serialization by introducing and using a msgspec_json alias for all msgspec.json Encoder/Decoder instances, update Falcon ASGI/media imports, and adjust tests and error handling accordingly.

Bug Fixes:
- Use sa_exc.IntegrityError in tests instead of sa.exc.IntegrityError to catch database integrity errors
- Ensure Falcon ASGI and media modules are explicitly imported for WebSocket and media support

Enhancements:
- Introduce msgspec_json alias from msgspec.json and replace all msgspec.json usage across codebase
- Refactor WebSocket, OpenRouter client, and resource code to use msgspec_json for encoding and decoding messages

Tests:
- Update tests to use msgspec_json alias for encoding/decoding and adjust DummyClient fixture setup
- Refactor tests to catch sa_exc.IntegrityError and remove redundant client attribute assignments in tests