### PR TITLE
Implement stateful chat endpoint

### DIFF
--- a/docs/chat-endpoint-openapi.yaml
+++ b/docs/chat-endpoint-openapi.yaml
@@ -113,6 +113,7 @@ components:
           type: string
         model:
           type: string
+          nullable: true
       required:
         - message
     Message:

--- a/docs/chat-endpoint-openapi.yaml
+++ b/docs/chat-endpoint-openapi.yaml
@@ -26,6 +26,35 @@ paths:
                   - answer
         '400':
           $ref: '#/components/responses/Problem'
+  /chat/state:
+    post:
+      summary: Stateful chat with an assistant model
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatStateRequest'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversation_id:
+                    type: string
+                    format: uuid
+                  answer:
+                    type: string
+                required:
+                  - conversation_id
+                  - answer
+        '400':
+          $ref: '#/components/responses/Problem'
+        '404':
+          $ref: '#/components/responses/Problem'
   /auth/openrouter-token:
     post:
       summary: Store the user's OpenRouter API key
@@ -67,6 +96,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Message'
+      required:
+        - message
+    ChatStateRequest:
+      type: object
+      properties:
+        conversation_id:
+          type: string
+          format: uuid
+        message:
+          type: string
+        model:
+          type: string
       required:
         - message
     Message:

--- a/docs/chat-endpoint-openapi.yaml
+++ b/docs/chat-endpoint-openapi.yaml
@@ -104,6 +104,7 @@ components:
         conversation_id:
           type: string
           format: uuid
+          nullable: true
         message:
           type: string
         model:

--- a/docs/chat-endpoint-openapi.yaml
+++ b/docs/chat-endpoint-openapi.yaml
@@ -26,6 +26,8 @@ paths:
                   - answer
         '400':
           $ref: '#/components/responses/Problem'
+        '401':
+          $ref: '#/components/responses/Problem'
   /chat/state:
     post:
       summary: Stateful chat with an assistant model
@@ -52,6 +54,8 @@ paths:
                   - conversation_id
                   - answer
         '400':
+          $ref: '#/components/responses/Problem'
+        '401':
           $ref: '#/components/responses/Problem'
         '404':
           $ref: '#/components/responses/Problem'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "httpx>=0.27",
   "msgspec>=0.19,<0.20",
   "aiosqlite>=0.21.0",
+  "uuid7>=0.1",
 ]
 
 [dependency-groups]

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -22,7 +22,12 @@ from .msgspec_support import (
     json_handler,
 )
 from .openrouter_service import OpenRouterService
-from .resources import ChatResource, HealthResource, OpenRouterTokenResource
+from .resources import (
+    ChatResource,
+    ChatStateResource,
+    HealthResource,
+    OpenRouterTokenResource,
+)
 from .session import SessionManager
 
 
@@ -76,6 +81,7 @@ def create_app(
     if db_session_factory is None:
         raise ValueError("db_session_factory is required")
     app.add_route("/chat", ChatResource(service, db_session_factory))
+    app.add_route("/chat/state", ChatStateResource(service, db_session_factory))
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource(db_session_factory))
     app.add_route("/health", HealthResource())
     app.add_route("/login", LoginResource(session, user, password))

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -1,0 +1,104 @@
+"""Helper routines for chat resources."""
+
+from __future__ import annotations
+
+import typing
+
+import falcon
+from sqlalchemy import select
+from uuid_extensions import uuid7
+
+from .models import Conversation, Message, UserAccount
+from .openrouter_service import (
+    OpenRouterService,
+    OpenRouterServiceBadGatewayError,
+    OpenRouterServiceTimeoutError,
+    chat_with_service,
+)
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    import uuid
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from .openrouter import ChatMessage
+
+
+async def load_user_and_api_key(
+    session_factory: typing.Callable[[], AsyncSession],
+    user_sub: str,
+) -> tuple[uuid.UUID, str | None]:
+    """Return the user's ID and decrypted OpenRouter API key."""
+
+    async with session_factory() as session:
+        stmt = select(UserAccount.id, UserAccount.openrouter_token_enc).where(
+            UserAccount.google_sub == user_sub
+        )
+        result = await session.execute(stmt)
+        row = result.one_or_none()
+
+    if row is None:
+        raise falcon.HTTPUnauthorized(description="invalid or missing user record")
+
+    user_id, token = typing.cast("tuple[uuid.UUID, bytes | str | None]", row)
+    api_key = token.decode() if isinstance(token, bytes) else token
+    if api_key is not None and not api_key.strip():
+        api_key = None
+    return user_id, api_key
+
+
+async def generate_answer(
+    service: OpenRouterService,
+    api_key: str,
+    messages: list[ChatMessage],
+    model: str | None,
+) -> str:
+    """Call the chat service and return the assistant's reply."""
+
+    try:
+        completion = await chat_with_service(service, api_key, messages, model=model)
+    except OpenRouterServiceTimeoutError:
+        raise falcon.HTTPGatewayTimeout() from None
+    except OpenRouterServiceBadGatewayError as exc:
+        raise falcon.HTTPBadGateway(description=str(exc)) from None
+
+    if not completion.choices:
+        raise falcon.HTTPBadGateway(description="no completion choices")
+    return completion.choices[0].message.content or ""
+
+
+async def get_or_create_conversation(
+    session: AsyncSession,
+    conv_id: uuid.UUID | None,
+    user_id: uuid.UUID,
+) -> Conversation:
+    """Return an existing conversation or create a new one."""
+
+    conv: Conversation | None = None
+    if conv_id is not None:
+        conv = await session.get(Conversation, conv_id)
+        if conv is None or conv.user_id != user_id:
+            raise falcon.HTTPNotFound()
+    if conv is None:
+        conv = Conversation(
+            id=typing.cast("uuid.UUID", uuid7(as_type="uuid")),
+            user_id=user_id,
+        )
+        session.add(conv)
+        await session.flush()
+    return conv
+
+
+async def list_conversation_messages(
+    session: AsyncSession,
+    conv_id: uuid.UUID,
+) -> list[Message]:
+    """Return messages for ``conv_id`` ordered by creation time."""
+
+    stmt = (
+        select(Message)
+        .where(Message.conversation_id == conv_id)
+        .order_by(Message.created_at)
+    )
+    result = await session.execute(stmt)
+    return typing.cast("list[Message]", result.scalars().all())

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -130,14 +130,6 @@ async def _get_or_create_conversation(
         if conv is None or conv.user_id != user_id:
             raise falcon.HTTPNotFound()
     if conv is None:
-        stmt = (
-            select(Conversation)
-            .where(Conversation.user_id == user_id)
-            .with_for_update()
-        )
-        result = await session.execute(stmt)
-        conv = result.scalar_one_or_none()
-    if conv is None:
         conv = Conversation(id=uuid7(), user_id=user_id)
         session.add(conv)
         await session.flush()

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -11,19 +11,23 @@ import falcon
 import falcon.asgi
 import msgspec
 from msgspec import json as msgspec_json
-from sqlalchemy import select, update
-from uuid_extensions import uuid7
+from sqlalchemy import update
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
-from .models import Conversation, Message, MessageRole, UserAccount
+from .chat_service import (
+    generate_answer,
+    get_or_create_conversation,
+    list_conversation_messages,
+    load_user_and_api_key,
+)
+from .models import Message, MessageRole, UserAccount
 from .openrouter import ChatMessage, Role, StreamChoice
 from .openrouter_service import (
     OpenRouterService,
     OpenRouterServiceBadGatewayError,
     OpenRouterServiceTimeoutError,
-    chat_with_service,
     stream_chat_with_service,
 )
 
@@ -66,80 +70,6 @@ class ChatStateRequest(msgspec.Struct):
     model: str | None = None
 
 
-async def _load_user_and_api_key(
-    session_factory: typing.Callable[[], AsyncSession],
-    user_sub: str,
-) -> tuple[uuid.UUID, str | None]:
-    """Return the user's ID and decrypted OpenRouter API key."""
-
-    async with session_factory() as session:
-        stmt = select(UserAccount.id, UserAccount.openrouter_token_enc).where(
-            UserAccount.google_sub == user_sub
-        )
-        result = await session.execute(stmt)
-        row = result.one_or_none()
-    if row is None:
-        raise falcon.HTTPUnauthorized()
-    user_id, token = typing.cast("tuple[uuid.UUID, bytes | str | None]", row)
-    api_key = token.decode() if isinstance(token, bytes) else token
-    if api_key is not None and not api_key.strip():
-        api_key = None
-    return user_id, api_key
-
-
-async def _generate_answer(
-    service: OpenRouterService,
-    api_key: str,
-    messages: list[ChatMessage],
-    model: str | None,
-) -> str:
-    """Call the chat service and return the assistant's reply."""
-
-    try:
-        completion = await chat_with_service(service, api_key, messages, model=model)
-    except OpenRouterServiceTimeoutError:
-        raise falcon.HTTPGatewayTimeout() from None
-    except OpenRouterServiceBadGatewayError as exc:
-        raise falcon.HTTPBadGateway(description=str(exc)) from None
-
-    if not completion.choices:
-        raise falcon.HTTPBadGateway(description="no completion choices")
-    return completion.choices[0].message.content or ""
-
-
-async def _get_or_create_conversation(
-    session: AsyncSession,
-    conv_id: uuid.UUID | None,
-    user_id: uuid.UUID,
-) -> Conversation:
-    """Return an existing conversation or create a new one."""
-
-    conv: Conversation | None = None
-    if conv_id is not None:
-        conv = await session.get(Conversation, conv_id)
-        if conv is None or conv.user_id != user_id:
-            raise falcon.HTTPNotFound()
-    if conv is None:
-        conv = Conversation(
-            id=typing.cast("uuid.UUID", uuid7(as_type="uuid")), user_id=user_id
-        )
-        session.add(conv)
-        await session.flush()
-    return conv
-
-
-async def _list_conversation_messages(
-    session: AsyncSession, conv_id: uuid.UUID
-) -> list[Message]:
-    """Return messages for ``conv_id`` ordered by creation time."""
-
-    stmt = (
-        select(Message)
-        .where(Message.conversation_id == conv_id)
-        .order_by(Message.created_at)
-    )
-    result = await session.execute(stmt)
-    return typing.cast("list[Message]", result.scalars().all())
 
 
 class ChatResource:
@@ -167,7 +97,7 @@ class ChatResource:
 
     async def _get_api_key(self, user: str) -> str | None:
         try:
-            _, api_key = await _load_user_and_api_key(self._session_factory, user)
+            _, api_key = await load_user_and_api_key(self._session_factory, user)
         except falcon.HTTPUnauthorized:
             return None
         return api_key
@@ -232,11 +162,11 @@ class ChatResource:
         model = body.model
 
         user = typing.cast("str", req.context["user"])
-        _, api_key = await _load_user_and_api_key(self._session_factory, user)
+        _, api_key = await load_user_and_api_key(self._session_factory, user)
         if api_key is None:
             raise falcon.HTTPUnauthorized(description="missing OpenRouter token")
 
-        answer = await _generate_answer(
+        answer = await generate_answer(
             self._service,
             api_key,
             history,
@@ -324,32 +254,18 @@ class ChatStateResource:
         body: ChatStateRequest,
     ) -> None:
         user_sub = typing.cast("str", req.context["user"])
-        user_id, api_key = await _load_user_and_api_key(self._session_factory, user_sub)
+        user_id, api_key = await load_user_and_api_key(self._session_factory, user_sub)
         if api_key is None:
             raise falcon.HTTPUnauthorized(description="missing OpenRouter token")
 
         async with self._session_factory() as session:
             async with session.begin():
-                conv = await _get_or_create_conversation(
+                conv = await get_or_create_conversation(
                     session, body.conversation_id, user_id
                 )
-                history_rows = await _list_conversation_messages(session, conv.id)
+                history_rows = await list_conversation_messages(session, conv.id)
                 last_id = history_rows[-1].id if history_rows else None
 
-            messages = [
-                ChatMessage(role=typing.cast("Role", m.role.value), content=m.content)
-                for m in history_rows
-            ]
-            messages.append(ChatMessage(role="user", content=body.message))
-
-            answer = await _generate_answer(
-                self._service,
-                api_key,
-                messages,
-                body.model,
-            )
-
-            async with session.begin():
                 user_msg = Message(
                     conversation_id=conv.id,
                     parent_id=last_id,
@@ -361,6 +277,20 @@ class ChatStateResource:
                 if conv.root_message_id is None:
                     conv.root_message_id = user_msg.id
 
+            messages = [
+                ChatMessage(role=typing.cast("Role", m.role.value), content=m.content)
+                for m in history_rows
+            ]
+            messages.append(ChatMessage(role="user", content=body.message))
+
+            answer = await generate_answer(
+                self._service,
+                api_key,
+                messages,
+                body.model,
+            )
+
+            async with session.begin():
                 assistant_msg = Message(
                     conversation_id=conv.id,
                     parent_id=user_msg.id,

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -4,16 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import secrets
-import time
 import typing
-import uuid
+import uuid  # noqa: TC003
 
 import falcon
 import falcon.asgi
 import msgspec
 from msgspec import json as msgspec_json
 from sqlalchemy import select, update
+from uuid_extensions import uuid7 as uuid7_lib
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -70,12 +69,10 @@ class ChatStateRequest(msgspec.Struct):
 def uuid7() -> uuid.UUID:
     """Return a time-ordered UUIDv7."""
 
-    ts_ms = int(time.time_ns() // 1_000_000)
-    rand_a = secrets.randbits(12)
-    rand_b = secrets.randbits(62)
-    hi = (ts_ms << 16) | (0x7000 | rand_a)
-    lo = 0x8000000000000000 | rand_b
-    return uuid.UUID(int=(hi << 64) | lo)
+    # ``uuid_extensions.uuid7`` supports returning the UUID in different formats.
+    # Explicitly request a UUID object to keep the return type stable for
+    # callers.
+    return typing.cast("uuid.UUID", uuid7_lib(as_type="uuid"))
 
 
 async def _load_user_and_api_key(

--- a/tests/test_stateful_chat.py
+++ b/tests/test_stateful_chat.py
@@ -57,6 +57,7 @@ async def test_stateful_chat_creates_conversation(
     assert resp.status_code == HTTPStatus.OK
     data = resp.json()
     conv_id = uuid.UUID(data["conversation_id"])
+    assert conv_id.version == 7
     assert data["answer"] == "hi"
     async with db_session_factory() as session:
         conv = await session.get(Conversation, conv_id)

--- a/tests/test_stateful_chat.py
+++ b/tests/test_stateful_chat.py
@@ -1,0 +1,135 @@
+import base64
+import typing
+import uuid
+from http import HTTPStatus
+
+import pytest
+from falcon import asgi
+from httpx import ASGITransport, AsyncClient
+from pytest_httpx import HTTPXMock
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bournemouth.app import create_app
+from bournemouth.models import Conversation, Message
+
+
+@pytest.fixture()
+def app(db_session_factory: typing.Callable[[], AsyncSession]) -> asgi.App:
+    return create_app(db_session_factory=db_session_factory)
+
+
+async def _login(client: AsyncClient) -> None:
+    credentials = base64.b64encode(b"admin:adminpass").decode()
+    resp = await client.post(
+        "/login", headers={"Authorization": f"Basic {credentials}"}
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert "session" in resp.cookies
+
+
+@pytest.mark.asyncio
+async def test_stateful_chat_creates_conversation(
+    app: asgi.App,
+    db_session_factory: typing.Callable[[], AsyncSession],
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "hi"}}
+            ],
+        },
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        await _login(client)
+        resp = await client.post("/chat/state", json={"message": "hello"})
+    assert resp.status_code == HTTPStatus.OK
+    data = resp.json()
+    conv_id = uuid.UUID(data["conversation_id"])
+    assert data["answer"] == "hi"
+    async with db_session_factory() as session:
+        conv = await session.get(Conversation, conv_id)
+        assert conv is not None
+        stmt = (
+            select(Message)
+            .where(Message.conversation_id == conv_id)
+            .order_by(Message.created_at)
+        )
+        result = await session.execute(stmt)
+        roles = [m.role for m in result.scalars().all()]
+        assert roles == ["user", "assistant"]
+
+
+@pytest.mark.asyncio
+async def test_stateful_chat_appends(
+    app: asgi.App,
+    db_session_factory: typing.Callable[[], AsyncSession],
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "1",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "a1"}}
+            ],
+        },
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        await _login(client)
+        resp1 = await client.post("/chat/state", json={"message": "a"})
+        conv_id = resp1.json()["conversation_id"]
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://openrouter.ai/api/v1/chat/completions",
+        json={
+            "id": "2",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "m",
+            "choices": [
+                {"index": 0, "message": {"role": "assistant", "content": "b1"}}
+            ],
+        },
+    )
+    async with AsyncClient(
+        transport=ASGITransport(app=typing.cast("typing.Any", app)),
+        base_url="https://test",
+    ) as client:
+        cookie = client.cookies["session"]
+        client.cookies.clear()
+        client.cookies.set("session", cookie)
+        resp2 = await client.post(
+            "/chat/state",
+            json={"message": "b", "conversation_id": conv_id},
+        )
+    assert resp2.status_code == HTTPStatus.OK
+    assert resp2.json()["conversation_id"] == conv_id
+    async with db_session_factory() as session:
+        stmt = (
+            select(Message)
+            .where(Message.conversation_id == uuid.UUID(conv_id))
+            .order_by(Message.created_at)
+        )
+        result = await session.execute(stmt)
+        roles = [m.role for m in result.scalars().all()]
+        assert roles == ["user", "assistant", "user", "assistant"]


### PR DESCRIPTION
## Summary
- implement `ChatStateResource` for storing conversation turns
- route `/chat/state` in the Falcon app
- extend OpenAPI spec for the new endpoint
- add tests covering conversation creation and continuation
- add helpers for retrieving user API keys and fetching answers
- refactor chat state session handling

## Testing
- `ruff check src/bournemouth/resources.py tests/test_stateful_chat.py src/bournemouth/app.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470a204e488322ab8df0a1dd8d88ba

## Summary by Sourcery

Implement a stateful chat endpoint with persistent conversation handling, extract common chat logic into reusable service helpers, update documentation, and expand test coverage.

New Features:
- Introduce a /chat/state endpoint via ChatStateResource to support persistent conversations
- Add chat_service module with helpers for user key loading, conversation management, and answer generation
- Extend OpenAPI spec with ChatStateRequest schema and stateful chat path

Bug Fixes:
- Strip and clear empty API keys on storage to support token removal
- Return HTTPUnauthorized for missing or invalid OpenRouter tokens instead of HTTPBadRequest

Enhancements:
- Refactor ChatResource to use load_user_and_api_key and generate_answer helpers
- Simplify WebSocket request decoding and centralize session queries and error handling

Build:
- Add uuid7 dependency for version-7 UUID generation

Documentation:
- Update OpenAPI documentation with stateful chat endpoint and request/response schemas

Tests:
- Add tests for stateful chat lifecycle, missing tokens, timeout handling, and empty token storage