### PR TITLE
Refactor service error handling

### DIFF
--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -40,6 +40,9 @@ async def _convert_service_errors() -> typing.AsyncIterator[None]:
     except OpenRouterServiceBadGatewayError as exc:
         _logger.exception("bad gateway from OpenRouter", exc_info=exc)
         raise falcon.HTTPBadGateway(description=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - unexpected failures
+        _logger.exception("unexpected error from OpenRouter", exc_info=exc)
+        raise falcon.HTTPInternalServerError() from exc
 
 
 async def load_user_and_api_key(

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import typing
 import uuid  # noqa: TC003
 
@@ -27,6 +28,8 @@ from .chat_service import (
 )
 from .models import Message, MessageRole, UserAccount
 from .openrouter import ChatMessage, Role, StreamChoice
+
+_logger = logging.getLogger(__name__)
 
 
 class HttpMessage(msgspec.Struct):
@@ -137,7 +140,8 @@ class ChatResource:
                         )
                         await ws.send_text(raw.decode())
                     break
-        except (falcon.HTTPGatewayTimeout, falcon.HTTPBadGateway):
+        except (falcon.HTTPGatewayTimeout, falcon.HTTPBadGateway) as exc:
+            _logger.exception("closing websocket due to upstream error", exc_info=exc)
             await ws.close(code=1011)
 
     async def on_post(

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -16,20 +16,17 @@ from sqlalchemy import update
 if typing.TYPE_CHECKING:  # pragma: no cover
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from .openrouter_service import OpenRouterService
+
 from .chat_service import (
     generate_answer,
     get_or_create_conversation,
     list_conversation_messages,
     load_user_and_api_key,
+    stream_answer,
 )
 from .models import Message, MessageRole, UserAccount
 from .openrouter import ChatMessage, Role, StreamChoice
-from .openrouter_service import (
-    OpenRouterService,
-    OpenRouterServiceBadGatewayError,
-    OpenRouterServiceTimeoutError,
-    stream_chat_with_service,
-)
 
 
 class HttpMessage(msgspec.Struct):
@@ -113,11 +110,11 @@ class ChatResource:
         """Stream chat completions back to the client."""
 
         try:
-            async for chunk in stream_chat_with_service(
+            async for chunk in stream_answer(
                 self._service,
                 api_key,
                 history,
-                model=model,
+                model,
             ):
                 choice: StreamChoice = chunk.choices[0]
                 if choice.delta.content:
@@ -140,9 +137,7 @@ class ChatResource:
                         )
                         await ws.send_text(raw.decode())
                     break
-        except OpenRouterServiceTimeoutError:
-            await ws.close(code=1011)
-        except OpenRouterServiceBadGatewayError:
+        except (falcon.HTTPGatewayTimeout, falcon.HTTPBadGateway):
             await ws.close(code=1011)
 
     async def on_post(


### PR DESCRIPTION
## Summary
- share error handling for OpenRouter service failures
- use helper in ChatResource streaming

## Testing
- `ruff check src/bournemouth/chat_service.py src/bournemouth/resources.py`
- `pyright`
- `pytest -q` *(fails: KeyboardInterrupt after tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68478974004883228065829ddc9f6d6b

## Summary by Sourcery

Refactor chat service and resource layers to centralize mapping of OpenRouter service errors to Falcon HTTP responses, introduce unified streaming error handling, and add tests to verify 500 responses for unexpected failures.

Bug Fixes:
- Ensure unexpected runtime errors from the chat service produce HTTP 500 responses without corrupting conversation state

Enhancements:
- Introduce _convert_service_errors context manager to translate OpenRouter errors into Falcon HTTP statuses with logging
- Add stream_answer helper to wrap stream_chat_with_service with unified error mapping
- Update generate_answer and resource streaming endpoints to use centralized error handling and simplify exception blocks

Tests:
- Add test in stateful chat to verify unexpected service errors return HTTP 500 and preserve user messages
- Add test for standard chat endpoint to verify unexpected errors return HTTP 500