### PR TITLE
Add CLI with Textual

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -1,0 +1,28 @@
+# Bournemouth CLI
+
+This project includes a small command line client for interacting with the chat
+API. It requires Python 3.13 and the dependencies defined in `pyproject.toml`.
+
+## Installation
+
+Install the project in editable mode and ensure the CLI dependencies are
+available:
+
+```bash
+uv pip install -e .
+```
+
+A console script named `bournemouth-chat` will be available after installation.
+
+## Usage
+
+```bash
+bournemouth-chat login
+bournemouth-chat token
+bournemouth-chat chat
+```
+
+The `login` command prompts for your username and password and stores the
+session cookie in `~/.bournemouth_cookie`. The `token` command saves your
+OpenRouter API key. After logging in and setting a token, use `chat` to start an
+interactive conversation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
   "msgspec>=0.19,<0.20",
   "aiosqlite>=0.21.0",
   "uuid7>=0.1",
+  "typer>=0.12",
+  "textual>=0.51",
 ]
 
 [dependency-groups]
@@ -33,7 +35,7 @@ docs = [
 ]
 
 [project.scripts]
-# placeholder for future CLI entry points
+bournemouth-chat = "bournemouth.cli:app"
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/src/bournemouth/cli.py
+++ b/src/bournemouth/cli.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import typing
+from pathlib import Path
+
+import httpx
+import typer
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Static, TextLog
+
+COOKIE_PATH = Path.home() / ".bournemouth_cookie"
+
+app = typer.Typer(help="Command line interface for Bournemouth chat")
+
+
+async def _login_request(host: str, username: str, password: str) -> str:
+    async with httpx.AsyncClient(base_url=host) as client:
+        resp = await client.post("/login", auth=(username, password))
+        resp.raise_for_status()
+        cookie = resp.cookies.get("session")
+        if not cookie:
+            raise RuntimeError("missing session cookie")
+        return cookie
+
+
+async def _token_request(host: str, cookie: str, token: str) -> bool:
+    async with httpx.AsyncClient(base_url=host, cookies={"session": cookie}) as client:
+        resp = await client.post("/auth/openrouter-token", json={"api_key": token})
+    return resp.status_code == 204
+
+
+async def _chat_request(
+    host: str, cookie: str, message: str, history: list[dict[str, str]]
+) -> str:
+    async with httpx.AsyncClient(base_url=host, cookies={"session": cookie}) as client:
+        resp = await client.post("/chat", json={"message": message, "history": history})
+        resp.raise_for_status()
+    data = typing.cast("dict[str, typing.Any]", resp.json())
+    return typing.cast("str", data.get("answer"))
+
+
+async def perform_login(
+    host: str, username: str, password: str, cookie_file: Path = COOKIE_PATH
+) -> str:
+    cookie = await _login_request(host, username, password)
+    cookie_file.write_text(cookie)
+    return cookie
+
+
+class LoginApp(App):  # pyright: ignore[reportUntypedBaseClass]
+    def __init__(self, host: str, cookie_file: Path) -> None:
+        super().__init__()
+        self.host = host
+        self.cookie_file = cookie_file
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="Username", id="user")
+        yield Input(placeholder="Password", password=True, id="pass")
+        yield Button("Login", id="login")
+        yield Static(id="status")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:  # pyright: ignore[reportUnknownArgumentType]
+        if event.button.id != "login":
+            return
+        username = typing.cast("str", self.query_one("#user", Input).value)
+        password = typing.cast("str", self.query_one("#pass", Input).value)
+        status = self.query_one("#status", Static)
+        try:
+            await perform_login(self.host, username, password, self.cookie_file)
+        except Exception as exc:  # noqa: BLE001
+            status.update(f"Login failed: {exc}")
+            return
+        status.update("Login successful")
+        await self.action_quit()
+
+
+class TokenApp(App):  # pyright: ignore[reportUntypedBaseClass]
+    def __init__(self, host: str, cookie: str) -> None:
+        super().__init__()
+        self.host = host
+        self.cookie = cookie
+
+    def compose(self) -> ComposeResult:
+        yield Input(placeholder="OpenRouter token", id="token")
+        yield Button("Save", id="save")
+        yield Static(id="status")
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:  # pyright: ignore[reportUnknownArgumentType]
+        if event.button.id != "save":
+            return
+        token = typing.cast("str", self.query_one("#token", Input).value)
+        status = self.query_one("#status", Static)
+        ok = await _token_request(self.host, self.cookie, token)
+        if ok:
+            status.update("Token saved")
+        else:
+            status.update("Failed to save token")
+
+
+class ChatApp(App):  # pyright: ignore[reportUntypedBaseClass]
+    def __init__(self, host: str, cookie: str) -> None:
+        super().__init__()
+        self.host = host
+        self.cookie = cookie
+        self.history: list[dict[str, str]] = []
+
+    def compose(self) -> ComposeResult:
+        yield TextLog(id="log")
+        yield Input(placeholder="Message", id="input")
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:  # pyright: ignore[reportUnknownArgumentType]
+        text = typing.cast("str", event.value)
+        log = self.query_one("#log", TextLog)
+        log.write(f"You: {text}")
+        answer = await _chat_request(self.host, self.cookie, text, self.history)
+        log.write(f"Assistant: {answer}")
+        self.history.append({"role": "user", "content": text})
+        self.history.append({"role": "assistant", "content": answer})
+        self.query_one("#input", Input).value = ""
+
+
+@app.command()  # pyright: ignore[reportUntypedFunctionDecorator]
+def login(host: str = "http://localhost:8000") -> None:
+    """Login to the chat server."""
+    LoginApp(host, COOKIE_PATH).run()
+
+
+@app.command()  # pyright: ignore[reportUntypedFunctionDecorator]
+def token(host: str = "http://localhost:8000") -> None:
+    """Store your OpenRouter token."""
+    if not COOKIE_PATH.exists():
+        typer.echo("Please login first.")
+        raise typer.Exit(code=1)
+    cookie = COOKIE_PATH.read_text().strip()
+    TokenApp(host, cookie).run()
+
+
+@app.command()  # pyright: ignore[reportUntypedFunctionDecorator]
+def chat(host: str = "http://localhost:8000") -> None:
+    """Chat with the assistant."""
+    if not COOKIE_PATH.exists():
+        typer.echo("Please login first.")
+        raise typer.Exit(code=1)
+    cookie = COOKIE_PATH.read_text().strip()
+    ChatApp(host, cookie).run()
+
+
+__all__ = [
+    "_chat_request",
+    "_token_request",
+    "app",
+    "perform_login",
+]

--- a/src/bournemouth/unittests/test_cli.py
+++ b/src/bournemouth/unittests/test_cli.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import typing
+
+import pytest
+
+from bournemouth import cli
+
+if typing.TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_httpx import HTTPXMock
+
+
+@pytest.mark.asyncio
+async def test_login_saves_cookie(httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+    cookie_file = tmp_path / "cookie"
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/login",
+        json={"status": "logged_in"},
+        headers={"set-cookie": "session=abc123"},
+    )
+    await cli.perform_login(
+        "http://localhost:8000", "alice", "secret", cookie_file=cookie_file
+    )
+    assert cookie_file.read_text() == "abc123"
+    req = httpx_mock.get_requests()[0]
+    assert req.headers["authorization"].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_token_posts_correctly(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/auth/openrouter-token",
+        status_code=204,
+    )
+    ok = await cli._token_request("http://localhost:8000", "abc123", "tok")  # pyright: ignore[reportPrivateUsage]
+    assert ok
+    req = httpx_mock.get_requests()[0]
+    assert req.headers["cookie"] == "session=abc123"
+    assert json.loads(req.content.decode()) == {"api_key": "tok"}
+
+
+@pytest.mark.asyncio
+async def test_chat_sends_history(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="POST",
+        url="http://localhost:8000/chat",
+        json={"answer": "hi"},
+    )
+    history = [{"role": "assistant", "content": "hello"}]
+    answer = await cli._chat_request("http://localhost:8000", "abc123", "hi", history)  # pyright: ignore[reportPrivateUsage]
+    assert answer == "hi"
+    req = httpx_mock.get_requests()[0]
+    sent = json.loads(req.content.decode())
+    assert sent["message"] == "hi"
+    assert sent["history"] == history
+    assert req.headers["cookie"] == "session=abc123"


### PR DESCRIPTION
## Summary
- implement Textual CLI using Typer for login/token/chat
- store session cookie in `~/.bournemouth_cookie`
- document CLI usage
- add unit tests using pytest-httpx
- expose `bournemouth-chat` script

## Testing
- `ruff format src/bournemouth/cli.py src/bournemouth/unittests/test_cli.py pyproject.toml`
- `ruff check src/bournemouth/cli.py src/bournemouth/unittests/test_cli.py pyproject.toml`
- `pyright`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684ce476cdb88322977b740ec0687d1d