### PR TITLE
Add startup script for api

### DIFF
--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -16,4 +16,8 @@
 set -eu
 SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
+command -v uv >/dev/null 2>&1 || {
+    echo "Error: uv CLI not found" >&2
+    exit 1
+}
 exec uv run granian --factory bournemouth.app:create_app "$@"

--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+# Start the bournemouth API server using uv and granian.
+# Usage: scripts/start-api.sh [granian options]
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR/.."
+uv run granian --factory bournemouth.app:create_app "$@"

--- a/scripts/start-api.sh
+++ b/scripts/start-api.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env sh
-# Start the bournemouth API server using uv and granian.
-# Usage: scripts/start-api.sh [granian options]
-set -e
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Start the bournemouth API server.
+#
+# Prerequisites:
+#   - uv CLI must be installed and available on PATH
+#   - granian Python package must be installed
+#
+# Usage:
+#   scripts/start-api.sh [granian options]
+#   scripts/start-api.sh --reload
+#   scripts/start-api.sh --host 0.0.0.0 --port 8000
+#
+# The uv command executes the granian server with the application's factory
+# function. Extra arguments are passed directly to granian.
+
+set -eu
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 cd "$SCRIPT_DIR/.."
-uv run granian --factory bournemouth.app:create_app "$@"
+exec uv run granian --factory bournemouth.app:create_app "$@"


### PR DESCRIPTION
## Summary
- provide `scripts/start-api.sh` to launch the server with `uv` and `granian`

## Testing
- `ruff format --silent`
- `ruff check --quiet`
- `pyright`
- `pytest -q`
- `biome check src tests docs tsconfig.json`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684ce4e4f338832298b9bc3d7ad19dfd

## Summary by Sourcery

New Features:
- Add `scripts/start-api.sh` to launch the Bournemouth API server using `uv` and the `granian` factory function with configurable options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a new script to simplify starting the Bournemouth API server from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->