### PR TITLE
Fix websocket streaming test setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "aiosqlite>=0.21.0",
   "uuid7>=0.1",
   "falcon-pachinko==0.1.0a1",
+  "uuid-v7>=1.0.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "httpx>=0.27",
   "msgspec>=0.19,<0.20",
   "aiosqlite>=0.21.0",
-  "uuid7>=0.1",
   "falcon-pachinko==0.1.0a1",
   "uuid-v7>=1.0.0",
 ]

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -113,7 +113,7 @@ async def get_or_create_conversation(
             raise falcon.HTTPNotFound()
     if conv is None:
         conv = Conversation(
-            id=typing.cast("uuid.UUID", uuid7(as_type="uuid")),
+            id=typing.cast("uuid.UUID", uuid7(return_type="uuid")),
             user_id=user_id,
         )
         session.add(conv)

--- a/src/uuid_extensions.py
+++ b/src/uuid_extensions.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import uuid
+
+try:
+    from uuid6 import uuid7 as _uuid7
+except Exception:  # pragma: no cover
+    from uuid import uuid4 as _uuid7
+
+
+def uuid7(*, as_type: str | None = None) -> uuid.UUID | str:
+    u = _uuid7()
+    if as_type == "uuid":
+        return u
+    return str(u)

--- a/src/uuid_extensions.py
+++ b/src/uuid_extensions.py
@@ -1,12 +1,27 @@
+"""UUID generation utilities with fallback support.
+
+Provide UUIDv7 generation using the :mod:`uuid-v7` library when available,
+falling back to :func:`uuid.uuid4` otherwise.
+"""
+
 from __future__ import annotations
 import uuid
 
 try:
-    from uuid6 import uuid7 as _uuid7
-except Exception:  # pragma: no cover
+    from uuid_v7.base import uuid7 as _uuid7
+except ImportError:  # pragma: no cover
     from uuid import uuid4 as _uuid7
 
 
-def uuid7(*, as_type: str | None = None) -> uuid.UUID | str:
+def uuid7(*, return_type: str | None = None) -> uuid.UUID | str:
+    """Return a UUIDv7 identifier or a string representation.
+
+    Args:
+        return_type: Specify ``"uuid"`` to return a :class:`uuid.UUID` object,
+            anything else yields the hex string.
+
+    Returns:
+        A UUID object or string value depending on ``return_type``.
+    """
     u = _uuid7()
-    return u if as_type == "uuid" else str(u)
+    return u if return_type == "uuid" else str(u)

--- a/src/uuid_extensions.py
+++ b/src/uuid_extensions.py
@@ -9,6 +9,4 @@ except Exception:  # pragma: no cover
 
 def uuid7(*, as_type: str | None = None) -> uuid.UUID | str:
     u = _uuid7()
-    if as_type == "uuid":
-        return u
-    return str(u)
+    return u if as_type == "uuid" else str(u)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import sys
 import typing
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
@@ -10,8 +12,6 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from bournemouth.models import Base, UserAccount
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 pytest_plugins = ["pytest_httpx"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ import sys
 import typing
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BASE_DIR / "src"))
+sys.path.insert(0, str(BASE_DIR))
 
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import (

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -46,7 +46,7 @@ async def test_websocket_streams_chat(
         b'"delta": {"content": "hi"}}]}\n'
         b'data: {"id": "1", "object": "chat.completion.chunk", '
         b'"created": 1, "model": "m", "choices": [{"index": 0, '
-        b'"delta": {}, "finish_reason": "stop"}}]}\n'
+        b'"delta": {}, "finish_reason": "stop"}]}\n'
         b"data: \n"
     )
     httpx_mock.add_response(
@@ -136,6 +136,9 @@ async def test_websocket_multiplexes_requests(
             )
 
     monkeypatch.setattr("bournemouth.chat_service.stream_answer", fake_stream)
+    monkeypatch.setattr("bournemouth.resources.stream_answer", fake_stream)
+    import bournemouth.resources as r
+    monkeypatch.setitem(r.ChatResource._stream_chat.__globals__, "stream_answer", fake_stream)
 
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
@@ -156,16 +159,16 @@ async def test_websocket_multiplexes_requests(
             ).decode()
         )
         first = msgspec_json.decode(
-            await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
+            await asyncio.wait_for(ws.receive_text(), 2), type=ChatWsResponse
         )
         second = msgspec_json.decode(
-            await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
+            await asyncio.wait_for(ws.receive_text(), 2), type=ChatWsResponse
         )
         third = msgspec_json.decode(
-            await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
+            await asyncio.wait_for(ws.receive_text(), 2), type=ChatWsResponse
         )
         fourth = msgspec_json.decode(
-            await asyncio.wait_for(ws.receive_text(), 1), type=ChatWsResponse
+            await asyncio.wait_for(ws.receive_text(), 2), type=ChatWsResponse
         )
 
     results = [first, second, third, fourth]

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -140,7 +140,10 @@ async def test_websocket_multiplexes_requests(
         cookie = await _login(client)
 
     headers = {"cookie": f"session={cookie}"}
-    async with conductor.simulate_ws("/chat", headers=headers) as ws, ws_collector(ws) as coll:
+    async with (
+        conductor.simulate_ws("/chat", headers=headers) as ws,
+        ws_collector(ws) as coll,
+    ):
         await ws.send_text(
             msgspec_json.encode(
                 ChatWsRequest(transaction_id="t1", message="a")

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -47,7 +47,7 @@ def _patch_stream() -> typing.Callable[..., typing.AsyncIterator[StreamChunk]]:
         history: list[typing.Any],
         model: str | None,
     ) -> typing.AsyncIterator[StreamChunk]:
-        idx = 1 if not first_started.is_set() else 2
+        idx = 2 if first_started.is_set() else 1
         if idx == 1:
             first_started.set()
             await second_started.wait()

--- a/tests/ws_helpers.py
+++ b/tests/ws_helpers.py
@@ -1,0 +1,125 @@
+"""
+Light-weight utilities for asserting against WebSocket streams in pytest.
+
+Key idea
+--------
+Spin up a background *pump* task that feeds every incoming frame into
+an asyncio.Queue.  Tests interact purely with that queue, so we never
+block the event-loop on an unknown recv() – and we only apply a
+deadline once per logical expectation, not on every frame.
+
+Usage
+-----
+async with ws_collector(ws) as coll:
+    await ws.send_json({"prompt": "Hello"})
+    msgs = await coll.collect_until(lambda m: m.get("event") == "done")
+    assert "".join(m["content"] for m in msgs if m["event"] == "chunk") \
+           .startswith("Hello")
+
+Licence: ISC (same as project)
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Any, Self
+
+_T = Callable[[Any], bool]
+
+
+@dataclass(slots=True)
+class _Pump:
+    ws: Any
+    q: asyncio.Queue[Any] = field(default_factory=asyncio.Queue)
+    done: asyncio.Event = field(default_factory=asyncio.Event)
+    _task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> Self:
+        self._task = asyncio.create_task(self._run(), name="ws-pump")
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool | None:
+        await self.aclose()
+        return False
+
+    async def _run(self) -> None:
+        try:
+            while not self.ws.closed:
+                raw = await self.ws.receive_text()
+                try:
+                    msg = json.loads(raw)
+                except Exception:
+                    msg = raw
+                await self.q.put(msg)
+        except Exception:
+            pass
+        finally:
+            self.done.set()
+
+    async def next(self, *, timeout: float | None = None) -> Any:
+        if timeout is None:
+            return await self.q.get()
+        return await asyncio.wait_for(self.q.get(), timeout)
+
+    async def collect(self, n: int | None = None, *, timeout: float | None = None) -> list[Any]:
+        deadline: float | None = (
+            asyncio.get_event_loop().time() + timeout if timeout else None
+        )
+        out: list[Any] = []
+        while n is None or len(out) < n:
+            if deadline is not None:
+                left = deadline - asyncio.get_event_loop().time()
+                if left <= 0:
+                    raise TimeoutError("deadline reached")
+            else:
+                left = None
+            try:
+                msg = await self.next(timeout=left)
+            except asyncio.TimeoutError as e:
+                raise TimeoutError("deadline reached") from e
+            out.append(msg)
+            if self.done.is_set() and self.q.empty():
+                break
+        return out
+
+    async def collect_until(
+        self, predicate: _T, *, timeout: float | None = 5.0
+    ) -> list[Any]:
+        msgs: list[Any] = []
+        deadline: float | None = (
+            asyncio.get_event_loop().time() + timeout if timeout else None
+        )
+        while True:
+            if deadline is not None:
+                left = deadline - asyncio.get_event_loop().time()
+                if left <= 0:
+                    raise TimeoutError("deadline reached")
+            else:
+                left = None
+            msg = await self.next(timeout=left)
+            msgs.append(msg)
+            if predicate(msg):
+                return msgs
+
+    async def aclose(self) -> None:
+        if self._task and not self._task.done():
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        if not self.ws.closed:
+            await self.ws.close()
+
+
+@contextlib.asynccontextmanager
+async def ws_collector(ws: Any) -> AsyncIterator[_Pump]:
+    async with _Pump(ws) as pump:
+        yield pump

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,6 @@ dependencies = [
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "uuid-v7" },
-    { name = "uuid7" },
 ]
 
 [package.dev-dependencies]
@@ -111,7 +110,6 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uuid-v7", specifier = ">=1.0.0" },
-    { name = "uuid7", specifier = ">=0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -853,11 +851,3 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/8b/cbcb38c01d1fd9682043f3d7a3ef5eb0a628a2d7c917fec21b04ffc2cf98/uuid_v7-1.0.0-py3-none-any.whl", hash = "sha256:b27f8e1a90ad5c81577f8eaebf9ef67ab8b4dc8d0838c4fcc2e57fd52ebf7fff", size = 4665, upload-time = "2024-02-15T11:00:01.471Z" },
 ]
 
-[[package]]
-name = "uuid7"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/19/7472bd526591e2192926247109dbf78692e709d3e56775792fec877a7720/uuid7-0.1.0.tar.gz", hash = "sha256:8c57aa32ee7456d3cc68c95c4530bc571646defac01895cfc73545449894a63c", size = 14052, upload-time = "2021-12-29T01:38:21.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/77/8852f89a91453956582a85024d80ad96f30a41fed4c2b3dce0c9f12ecc7e/uuid7-0.1.0-py2.py3-none-any.whl", hash = "sha256:5e259bb63c8cb4aded5927ff41b444a80d0c7124e8a0ced7cf44efa1f5cccf61", size = 7477, upload-time = "2021-12-29T01:38:20.418Z" },
-]

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,7 @@ dependencies = [
     { name = "neo4j" },
     { name = "requests" },
     { name = "sqlalchemy" },
+    { name = "uuid-v7" },
     { name = "uuid7" },
 ]
 
@@ -109,6 +110,7 @@ requires-dist = [
     { name = "neo4j", specifier = ">=5.20" },
     { name = "requests", specifier = ">=2.31" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "uuid-v7", specifier = ">=1.0.0" },
     { name = "uuid7", specifier = ">=0.1" },
 ]
 
@@ -840,6 +842,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+]
+
+[[package]]
+name = "uuid-v7"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/94/b7c21adccab9cc3b5d7f7bf86855e9648cbdb93962a16c68f67d51af212d/uuid_v7-1.0.0.tar.gz", hash = "sha256:56eb79baa5c6c5cf02e9e8ce7652bda666bd7671a49fc9a3c3d4565aa7e0ba3b", size = 5093, upload-time = "2024-02-15T11:00:05.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/8b/cbcb38c01d1fd9682043f3d7a3ef5eb0a628a2d7c917fec21b04ffc2cf98/uuid_v7-1.0.0-py3-none-any.whl", hash = "sha256:b27f8e1a90ad5c81577f8eaebf9ef67ab8b4dc8d0838c4fcc2e57fd52ebf7fff", size = 4665, upload-time = "2024-02-15T11:00:01.471Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- fix import path for tests
- correct malformed JSON for websocket streaming data
- patch websocket test helpers for multiplexing

## Testing
- `pytest tests/test_chat_websocket.py::test_websocket_streams_chat -q`
- `pytest tests/test_chat_websocket.py::test_websocket_multiplexes_requests -q` *(fails: TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_e_68597c661a748322a84838438d5cd912

## Summary by Sourcery

Enhance and fix websocket streaming test setup by introducing a reusable ws_helpers collector, correcting import paths and JSON formatting, and parameterizing the app and resource to accept custom stream handlers; also unify UUIDv7 support with a new uuid_extensions module and update related dependencies.

New Features:
- Add ws_helpers module for non-blocking WebSocket message collection in tests
- Parameterize ChatResource via create_app to accept a custom stream_answer function
- Introduce uuid_extensions for UUIDv7 generation with fallback support

Bug Fixes:
- Fix import path for ws_helpers in websocket tests
- Correct malformed JSON in websocket stream test expectations
- Adjust uuid7 call arguments to match updated uuid-v7 API

Enhancements:
- Refactor websocket tests to extract fake stream logic into a reusable _patch_stream helper and use ws_collector for multiplexing
- Remove manual sys.path insertion from conftest for cleaner test setup

Build:
- Update project dependency from uuid7 to uuid-v7 in pyproject.toml

Tests:
- Add ws_helpers and update websocket streaming tests to use ws_collector for collecting and parsing messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected test data formatting for streaming chat completion responses.
	- Improved reliability of WebSocket multiplexing tests by ensuring consistent use of the fake streaming function and increasing message receive timeouts.

- **New Features**
	- Added support for customizable chat streaming responses in the chat API.
	- Introduced UUID version 7 generation with fallback for unique identifiers.
	- Provided a new utility for efficient WebSocket message collection and assertion in tests.

- **Tests**
	- Enhanced test setup to ensure dependencies are loaded in the correct order, improving test stability.
	- Refactored WebSocket tests to use improved message collection and dependency injection for better clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->