### PR TITLE
Inject dependencies via constructor for websocket resource

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "httpx>=0.27",
   "msgspec>=0.19,<0.20",
   "aiosqlite>=0.21.0",
-  "falcon-pachinko==0.1.0a1",
+  "falcon-pachinko==0.1.0a2",
   "uuid-v7>=1.0.0",
   "greenlet>=3.2.2",
 ]
@@ -51,7 +51,7 @@ build-backend = "setuptools.build_meta"
 package = true
 
 [tool.uv.sources]
-falcon-pachinko = { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha1/falcon_pachinko-0.1.0a1-py3-none-any.whl" }
+falcon-pachinko = { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha2/falcon_pachinko-0.1.0a2-py3-none-any.whl" }
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -107,7 +107,9 @@ def create_app(
     app.add_route("/chat/state", ChatStateResource(service, db_session_factory))
     app_with_ws.add_websocket_route(
         "/ws/chat",
-        ChatWsPachinkoResource(service, db_session_factory),
+        ChatWsPachinkoResource,
+        service,
+        db_session_factory,
     )
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource(db_session_factory))
     app.add_route("/health", HealthResource())

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -52,14 +52,12 @@ class ImageUrl(msgspec.Struct, array_like=True):
     detail: typing.Literal["auto", "low", "high"] = "auto"
 
 
-class ImageContentPart(msgspec.Struct):
+class ImageContentPart(msgspec.Struct, tag="image_url"):
     image_url: ImageUrl
-    type: typing.Literal["image_url"] = "image_url"
 
 
-class TextContentPart(msgspec.Struct):
+class TextContentPart(msgspec.Struct, tag="text"):
     text: str
-    type: typing.Literal["text"] = "text"
 
 
 ContentPart = TextContentPart | ImageContentPart

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -225,7 +225,10 @@ class ChatResource:
 
 
 class ChatWsPachinkoResource(WebSocketResource):
-    """Stateless chat using ``falcon-pachinko``."""
+    """Stateless chat using ``falcon-pachinko``.
+
+    Dependencies are supplied at construction time to avoid shared state.
+    """
 
     def __init__(
         self,

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "falcon", specifier = ">=3.1" },
-    { name = "falcon-pachinko", url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha1/falcon_pachinko-0.1.0a1-py3-none-any.whl" },
+    { name = "falcon-pachinko", url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha2/falcon_pachinko-0.1.0a2-py3-none-any.whl" },
     { name = "greenlet", specifier = ">=3.2.2" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "itsdangerous", specifier = ">=2.1" },
@@ -212,14 +212,14 @@ wheels = [
 
 [[package]]
 name = "falcon-pachinko"
-version = "0.1.0a1"
-source = { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha1/falcon_pachinko-0.1.0a1-py3-none-any.whl" }
+version = "0.1.0a2"
+source = { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha2/falcon_pachinko-0.1.0a2-py3-none-any.whl" }
 dependencies = [
     { name = "falcon" },
     { name = "msgspec" },
 ]
 wheels = [
-    { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha1/falcon_pachinko-0.1.0a1-py3-none-any.whl", hash = "sha256:9fe6aa937587b0f275c2fb654c73d0796888e7c721383cb7e36a6823e4a584d0" },
+    { url = "https://github.com/leynos/falcon-pachinko/releases/download/v0.1.0-alpha2/falcon_pachinko-0.1.0a2-py3-none-any.whl", hash = "sha256:e3ab1e20b24316a8e1ba11b806a8117d74157ca151ca22651eb3c21e377dafcb" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Summary
- pass dependencies to `ChatWsPachinkoResource` using `__init__`
- register a configured instance in the application factory

## Testing
- `pytest -q` *(fails: resource_cls must be a subclass of WebSocketResource)*

------
https://chatgpt.com/codex/tasks/task_e_6859fe7533988322a3b0308c73c48599

## Summary by Sourcery

Use constructor injection for ChatWsPachinkoResource, simplify decoder setup, refine OpenRouter content-part structs, and bump falcon-pachinko to v0.1.0a2

Enhancements:
- Inject OpenRouterService and session factory into ChatWsPachinkoResource via __init__ instead of class attributes
- Register WebSocket resource with its dependencies in the application factory
- Replace dynamic msgspec_json.Decoder instantiation with a direct call
- Annotate OpenRouter content-part structs with tags and remove redundant type fields
- Upgrade falcon-pachinko dependency to v0.1.0a2 and update the UV sources URL