### PR TITLE
Improve documentation coverage

### DIFF
--- a/src/bournemouth/errors.py
+++ b/src/bournemouth/errors.py
@@ -1,3 +1,5 @@
+"""Error-handling helpers for Falcon-based APIs."""
+
 from __future__ import annotations
 
 import logging

--- a/src/bournemouth/models/__init__.py
+++ b/src/bournemouth/models/__init__.py
@@ -1,3 +1,5 @@
+"""SQLAlchemy ORM models for the chat service."""
+
 from __future__ import annotations
 
 import datetime as dt

--- a/src/bournemouth/models/mixins.py
+++ b/src/bournemouth/models/mixins.py
@@ -1,3 +1,5 @@
+"""Reusable SQLAlchemy mixins for timestamp and UUID fields."""
+
 import datetime as dt
 import uuid
 

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -53,7 +53,19 @@ class AsyncMsgspecMiddleware:
         resource: object,
         params: dict[str, typing.Any],
     ) -> None:
-        """Convert JSON request bodies to ``msgspec.Struct`` instances."""
+        """Convert JSON request bodies to ``msgspec.Struct`` instances.
+
+        Parameters
+        ----------
+        req:
+            Incoming HTTP request.
+        resp:
+            HTTP response object (unused).
+        resource:
+            The resource handling the request.
+        params:
+            Parameter dictionary passed to the resource.
+        """
         schema_attr = f"{req.method.upper()}_SCHEMA"
         schema = getattr(resource, schema_attr, None)
         if schema is None:
@@ -71,7 +83,19 @@ async def handle_msgspec_validation_error(
     ex: msgspec.ValidationError,
     params: dict[str, typing.Any],
 ) -> None:
-    """Return a ``422`` response when msgspec validation fails."""
+    """Return a ``422`` response when msgspec validation fails.
+
+    Parameters
+    ----------
+    req:
+        Request that triggered the validation error.
+    resp:
+        Response object used to send the error.
+    ex:
+        The validation error raised by ``msgspec``.
+    params:
+        Parameters dictionary passed to the handler.
+    """
     raise falcon.HTTPUnprocessableEntity(
         title="Validation Error",
         description=str(ex),
@@ -94,6 +118,18 @@ class MsgspecWebSocketMiddleware:
         resource: object,
         params: dict[str, typing.Any],
     ) -> None:
-        """Expose encoder and decoder classes via ``req.context``."""
+        """Expose encoder and decoder classes via ``req.context``.
+
+        Parameters
+        ----------
+        req:
+            Incoming WebSocket request.
+        ws:
+            WebSocket connection instance.
+        resource:
+            The websocket resource.
+        params:
+            Parameter dictionary passed to the resource.
+        """
         req.context.msgspec_encoder = self.encoder
         req.context.msgspec_decoder_cls = self.decoder_cls

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -48,16 +48,19 @@ Role = typing.Literal["system", "user", "assistant", "tool"]
 
 
 class ImageUrl(msgspec.Struct, array_like=True):
+    """URL and resolution hint for an image content part."""
     url: str
     detail: typing.Literal["auto", "low", "high"] = "auto"
 
 
 class ImageContentPart(msgspec.Struct):
+    """Represents an image in a chat message."""
     image_url: ImageUrl
     type: typing.Literal["image_url"] = "image_url"
 
 
 class TextContentPart(msgspec.Struct):
+    """Represents plain text in a chat message."""
     text: str
     type: typing.Literal["text"] = "text"
 
@@ -66,6 +69,7 @@ ContentPart = TextContentPart | ImageContentPart
 
 
 class ChatMessage(msgspec.Struct):
+    """A single chat message sent to or returned from OpenRouter."""
     role: Role
     content: str | list[ContentPart]
     name: str | None = None
@@ -80,21 +84,25 @@ class ChatMessage(msgspec.Struct):
 
 
 class FunctionDescription(msgspec.Struct):
+    """Description of a callable tool function."""
     name: str
     parameters: dict[str, typing.Any]
     description: str | None = None
 
 
 class Tool(msgspec.Struct):
+    """Tool definition that can be called by the model."""
     function: FunctionDescription
     type: typing.Literal["function"] = "function"
 
 
 class ToolChoiceFunction(msgspec.Struct):
+    """Specify a single function to call."""
     name: str
 
 
 class ToolChoiceObject(msgspec.Struct):
+    """Structured ``tool_choice`` parameter."""
     type: typing.Literal["function"]
     function: ToolChoiceFunction
 
@@ -103,14 +111,16 @@ ToolChoice = typing.Literal["none", "auto", "required"] | ToolChoiceObject
 
 
 class ResponseFormat(msgspec.Struct):
+    """Preferred format for the assistant's response."""
     type: typing.Literal["text", "json_object"]
 
 
 class ProviderPreferences(msgspec.Struct, array_like=True, forbid_unknown_fields=False):
-    pass
+    """Placeholder for OpenRouter provider routing preferences."""
 
 
 class ChatCompletionRequest(msgspec.Struct, forbid_unknown_fields=True):
+    """Payload for ``/chat/completions`` requests."""
     model: str
     messages: list[ChatMessage]
     stream: bool = False
@@ -134,29 +144,34 @@ class ChatCompletionRequest(msgspec.Struct, forbid_unknown_fields=True):
 
 
 class FunctionCall(msgspec.Struct):
+    """Function call returned by the assistant."""
     name: str
     arguments: str
 
 
 class ToolCall(msgspec.Struct):
+    """Invocation of a tool within a message."""
     id: str
     function: FunctionCall
     type: typing.Literal["function"] = "function"
 
 
 class ResponseMessage(msgspec.Struct):
+    """Full message object returned in non-streaming responses."""
     role: str
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
 
 
 class ResponseDelta(msgspec.Struct):
+    """Partial message content used in streaming responses."""
     role: str | None = None
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
 
 
 class ChatCompletionChoice(msgspec.Struct):
+    """Choice object from a non-streaming completion."""
     index: int
     message: ResponseMessage
     finish_reason: str | None = None
@@ -164,6 +179,7 @@ class ChatCompletionChoice(msgspec.Struct):
 
 
 class StreamChoice(msgspec.Struct):
+    """Choice object from a streamed chunk."""
     index: int
     delta: ResponseDelta
     finish_reason: str | None = None
@@ -171,12 +187,14 @@ class StreamChoice(msgspec.Struct):
 
 
 class UsageStats(msgspec.Struct):
+    """Token usage information returned by the API."""
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
 
 
 class ChatCompletionResponse(msgspec.Struct, forbid_unknown_fields=False):
+    """Response body for non-streaming chat completion requests."""
     id: str
     object: typing.Literal["chat.completion"]
     created: int
@@ -187,6 +205,7 @@ class ChatCompletionResponse(msgspec.Struct, forbid_unknown_fields=False):
 
 
 class StreamChunk(msgspec.Struct, forbid_unknown_fields=False):
+    """A single chunk from a streaming completion."""
     id: str
     object: typing.Literal["chat.completion.chunk"]
     created: int
@@ -197,6 +216,7 @@ class StreamChunk(msgspec.Struct, forbid_unknown_fields=False):
 
 
 class OpenRouterAPIErrorDetails(msgspec.Struct, forbid_unknown_fields=False):
+    """Details section in an error response."""
     message: str
     code: str | int | None = None
     param: str | None = None
@@ -205,6 +225,7 @@ class OpenRouterAPIErrorDetails(msgspec.Struct, forbid_unknown_fields=False):
 
 
 class OpenRouterErrorResponse(msgspec.Struct, forbid_unknown_fields=False):
+    """Wrapper for API error information."""
     error: OpenRouterAPIErrorDetails
 
 

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -49,18 +49,21 @@ Role = typing.Literal["system", "user", "assistant", "tool"]
 
 class ImageUrl(msgspec.Struct, array_like=True):
     """URL and resolution hint for an image content part."""
+
     url: str
     detail: typing.Literal["auto", "low", "high"] = "auto"
 
 
 class ImageContentPart(msgspec.Struct):
     """Represents an image in a chat message."""
+
     image_url: ImageUrl
     type: typing.Literal["image_url"] = "image_url"
 
 
 class TextContentPart(msgspec.Struct):
     """Represents plain text in a chat message."""
+
     text: str
     type: typing.Literal["text"] = "text"
 
@@ -70,6 +73,7 @@ ContentPart = TextContentPart | ImageContentPart
 
 class ChatMessage(msgspec.Struct):
     """A single chat message sent to or returned from OpenRouter."""
+
     role: Role
     content: str | list[ContentPart]
     name: str | None = None
@@ -77,6 +81,7 @@ class ChatMessage(msgspec.Struct):
     tool_calls: typing.Any | None = None
 
     def __post_init__(self) -> None:  # pragma: no cover - executed by msgspec
+        """Validate message content and metadata."""
         if self.role == "tool" and not self.tool_call_id:
             raise ValueError("tool messages must include tool_call_id")
         if self.role != "user" and isinstance(self.content, list):
@@ -85,6 +90,7 @@ class ChatMessage(msgspec.Struct):
 
 class FunctionDescription(msgspec.Struct):
     """Description of a callable tool function."""
+
     name: str
     parameters: dict[str, typing.Any]
     description: str | None = None
@@ -92,17 +98,20 @@ class FunctionDescription(msgspec.Struct):
 
 class Tool(msgspec.Struct):
     """Tool definition that can be called by the model."""
+
     function: FunctionDescription
     type: typing.Literal["function"] = "function"
 
 
 class ToolChoiceFunction(msgspec.Struct):
     """Specify a single function to call."""
+
     name: str
 
 
 class ToolChoiceObject(msgspec.Struct):
     """Structured ``tool_choice`` parameter."""
+
     type: typing.Literal["function"]
     function: ToolChoiceFunction
 
@@ -112,15 +121,16 @@ ToolChoice = typing.Literal["none", "auto", "required"] | ToolChoiceObject
 
 class ResponseFormat(msgspec.Struct):
     """Preferred format for the assistant's response."""
+
     type: typing.Literal["text", "json_object"]
 
 
 class ProviderPreferences(msgspec.Struct, array_like=True, forbid_unknown_fields=False):
     """Placeholder for OpenRouter provider routing preferences."""
 
-
 class ChatCompletionRequest(msgspec.Struct, forbid_unknown_fields=True):
     """Payload for ``/chat/completions`` requests."""
+
     model: str
     messages: list[ChatMessage]
     stream: bool = False
@@ -145,12 +155,14 @@ class ChatCompletionRequest(msgspec.Struct, forbid_unknown_fields=True):
 
 class FunctionCall(msgspec.Struct):
     """Function call returned by the assistant."""
+
     name: str
     arguments: str
 
 
 class ToolCall(msgspec.Struct):
     """Invocation of a tool within a message."""
+
     id: str
     function: FunctionCall
     type: typing.Literal["function"] = "function"
@@ -158,6 +170,7 @@ class ToolCall(msgspec.Struct):
 
 class ResponseMessage(msgspec.Struct):
     """Full message object returned in non-streaming responses."""
+
     role: str
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
@@ -165,6 +178,7 @@ class ResponseMessage(msgspec.Struct):
 
 class ResponseDelta(msgspec.Struct):
     """Partial message content used in streaming responses."""
+
     role: str | None = None
     content: str | None = None
     tool_calls: list[ToolCall] | None = None
@@ -172,6 +186,7 @@ class ResponseDelta(msgspec.Struct):
 
 class ChatCompletionChoice(msgspec.Struct):
     """Choice object from a non-streaming completion."""
+
     index: int
     message: ResponseMessage
     finish_reason: str | None = None
@@ -180,6 +195,7 @@ class ChatCompletionChoice(msgspec.Struct):
 
 class StreamChoice(msgspec.Struct):
     """Choice object from a streamed chunk."""
+
     index: int
     delta: ResponseDelta
     finish_reason: str | None = None
@@ -188,6 +204,7 @@ class StreamChoice(msgspec.Struct):
 
 class UsageStats(msgspec.Struct):
     """Token usage information returned by the API."""
+
     prompt_tokens: int
     completion_tokens: int
     total_tokens: int
@@ -195,6 +212,7 @@ class UsageStats(msgspec.Struct):
 
 class ChatCompletionResponse(msgspec.Struct, forbid_unknown_fields=False):
     """Response body for non-streaming chat completion requests."""
+
     id: str
     object: typing.Literal["chat.completion"]
     created: int
@@ -206,6 +224,7 @@ class ChatCompletionResponse(msgspec.Struct, forbid_unknown_fields=False):
 
 class StreamChunk(msgspec.Struct, forbid_unknown_fields=False):
     """A single chunk from a streaming completion."""
+
     id: str
     object: typing.Literal["chat.completion.chunk"]
     created: int
@@ -217,6 +236,7 @@ class StreamChunk(msgspec.Struct, forbid_unknown_fields=False):
 
 class OpenRouterAPIErrorDetails(msgspec.Struct, forbid_unknown_fields=False):
     """Details section in an error response."""
+
     message: str
     code: str | int | None = None
     param: str | None = None
@@ -226,6 +246,7 @@ class OpenRouterAPIErrorDetails(msgspec.Struct, forbid_unknown_fields=False):
 
 class OpenRouterErrorResponse(msgspec.Struct, forbid_unknown_fields=False):
     """Wrapper for API error information."""
+
     error: OpenRouterAPIErrorDetails
 
 

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -39,7 +39,19 @@ class OpenRouterService:
         timeout_config: httpx.Timeout | None = None,
         max_clients: int = 10,
     ) -> None:
-        """Initialize the service with default client configuration."""
+        """Initialize the service with default client configuration.
+
+        Parameters
+        ----------
+        default_model:
+            The model used when ``model`` is not supplied to chat methods.
+        base_url:
+            Base URL for OpenRouter's API.
+        timeout_config:
+            Optional timeout settings passed to ``httpx``.
+        max_clients:
+            Maximum number of cached clients.
+        """
         self.default_model = default_model
         self.base_url = base_url
         self.timeout_config = timeout_config
@@ -52,7 +64,13 @@ class OpenRouterService:
 
     @classmethod
     def from_env(cls) -> OpenRouterService:
-        """Create a service using ``OPENROUTER_*`` environment variables."""
+        """Create a service using ``OPENROUTER_*`` environment variables.
+
+        Returns
+        -------
+        OpenRouterService
+            Service configured from environment variables.
+        """
         model = os.getenv("OPENROUTER_MODEL") or DEFAULT_MODEL
         base_url = os.getenv("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL
         return cls(default_model=model, base_url=base_url)
@@ -65,7 +83,13 @@ class OpenRouterService:
                 self._entered = True
 
     async def __aenter__(self) -> OpenRouterService:
-        """Enter the service's context manager."""
+        """Enter the service's context manager.
+
+        Returns
+        -------
+        OpenRouterService
+            The service instance itself.
+        """
         await self._ensure_stack()
         return self
 
@@ -107,7 +131,13 @@ class OpenRouterService:
             return client
 
     async def remove_client(self, api_key: str) -> None:
-        """Remove and close the cached client for ``api_key``."""
+        """Remove and close the cached client for ``api_key``.
+
+        Parameters
+        ----------
+        api_key:
+            API key whose associated client should be closed and removed.
+        """
         async with self._lock:
             client = self._clients.pop(api_key, None)
         if client is not None:
@@ -120,7 +150,22 @@ class OpenRouterService:
         *,
         model: str | None = None,
     ) -> ChatCompletionResponse:
-        """Request a non-streaming chat completion from OpenRouter."""
+        """Request a non-streaming chat completion from OpenRouter.
+
+        Parameters
+        ----------
+        api_key:
+            OpenRouter API key to authenticate the request.
+        messages:
+            Conversation history to send to the API.
+        model:
+            Optional model override.
+
+        Returns
+        -------
+        ChatCompletionResponse
+            Parsed response from OpenRouter.
+        """
         request = ChatCompletionRequest(
             model=model or self.default_model,
             messages=messages,
@@ -135,7 +180,22 @@ class OpenRouterService:
         *,
         model: str | None = None,
     ) -> typing.AsyncIterator[StreamChunk]:
-        """Stream a chat completion from OpenRouter."""
+        """Stream a chat completion from OpenRouter.
+
+        Parameters
+        ----------
+        api_key:
+            OpenRouter API key to authenticate the request.
+        messages:
+            Conversation history to send to the API.
+        model:
+            Optional model override.
+
+        Yields
+        ------
+        StreamChunk
+            Chunks of the streamed completion.
+        """
         request = ChatCompletionRequest(
             model=model or self.default_model,
             messages=messages,
@@ -167,6 +227,22 @@ async def chat_with_service(
 ) -> ChatCompletionResponse:
     """Safely call ``service.chat_completion`` and map errors.
 
+    Parameters
+    ----------
+    service:
+        Service instance used to perform the request.
+    api_key:
+        OpenRouter API key for authentication.
+    messages:
+        Conversation history to send to the API.
+    model:
+        Optional model override.
+
+    Returns
+    -------
+    ChatCompletionResponse
+        Parsed response from the service.
+
     Raises
     ------
     OpenRouterServiceTimeoutError
@@ -190,6 +266,22 @@ async def stream_chat_with_service(
     model: str | None = None,
 ) -> typing.AsyncIterator[StreamChunk]:
     """Safely call ``service.stream_chat_completion`` and map errors.
+
+    Parameters
+    ----------
+    service:
+        Service instance used to perform the request.
+    api_key:
+        OpenRouter API key for authentication.
+    messages:
+        Conversation history to send to the API.
+    model:
+        Optional model override.
+
+    Yields
+    ------
+    StreamChunk
+        Chunks of the streamed completion.
 
     Raises
     ------

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -165,7 +165,15 @@ async def chat_with_service(
     *,
     model: str | None = None,
 ) -> ChatCompletionResponse:
-    """Safely call ``service.chat_completion`` and map errors."""
+    """Safely call ``service.chat_completion`` and map errors.
+
+    Raises
+    ------
+    OpenRouterServiceTimeoutError
+        If the request times out.
+    OpenRouterServiceBadGatewayError
+        When OpenRouter returns a network, server, or API-level error.
+    """
     try:
         return await service.chat_completion(api_key, messages, model=model)
     except OpenRouterTimeoutError as exc:
@@ -181,7 +189,15 @@ async def stream_chat_with_service(
     *,
     model: str | None = None,
 ) -> typing.AsyncIterator[StreamChunk]:
-    """Safely call ``service.stream_chat_completion`` and map errors."""
+    """Safely call ``service.stream_chat_completion`` and map errors.
+
+    Raises
+    ------
+    OpenRouterServiceTimeoutError
+        If the request times out.
+    OpenRouterServiceBadGatewayError
+        When OpenRouter returns a network, server, or API-level error.
+    """
     try:
         async for chunk in service.stream_chat_completion(
             api_key, messages, model=model

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -1,3 +1,6 @@
+
+"""Manage cached :class:`OpenRouterAsyncClient` instances by API key."""
+
 from __future__ import annotations
 
 import asyncio
@@ -36,6 +39,7 @@ class OpenRouterService:
         timeout_config: httpx.Timeout | None = None,
         max_clients: int = 10,
     ) -> None:
+        """Initialize the service with default client configuration."""
         self.default_model = default_model
         self.base_url = base_url
         self.timeout_config = timeout_config
@@ -48,19 +52,20 @@ class OpenRouterService:
 
     @classmethod
     def from_env(cls) -> OpenRouterService:
+        """Create a service using ``OPENROUTER_*`` environment variables."""
         model = os.getenv("OPENROUTER_MODEL") or DEFAULT_MODEL
         base_url = os.getenv("OPENROUTER_BASE_URL") or DEFAULT_BASE_URL
         return cls(default_model=model, base_url=base_url)
 
     async def _ensure_stack(self) -> None:
         """Enter the exit stack once in a thread-safe manner."""
-
         async with self._lock:
             if not self._entered:
                 await self._stack.__aenter__()
                 self._entered = True
 
     async def __aenter__(self) -> OpenRouterService:
+        """Enter the service's context manager."""
         await self._ensure_stack()
         return self
 
@@ -70,12 +75,14 @@ class OpenRouterService:
         exc: BaseException | None,
         tb: typing.Any,
     ) -> None:
+        """Close all clients when exiting the context manager."""
         await self._stack.aclose()
         self._clients.clear()
         self._stack = AsyncExitStack()
         self._entered = False
 
     async def aclose(self) -> None:
+        """Close all clients and reopen the context for reuse."""
         await self.__aexit__(None, None, None)
         # reopen for reuse
         await self._ensure_stack()
@@ -100,6 +107,7 @@ class OpenRouterService:
             return client
 
     async def remove_client(self, api_key: str) -> None:
+        """Remove and close the cached client for ``api_key``."""
         async with self._lock:
             client = self._clients.pop(api_key, None)
         if client is not None:
@@ -112,6 +120,7 @@ class OpenRouterService:
         *,
         model: str | None = None,
     ) -> ChatCompletionResponse:
+        """Request a non-streaming chat completion from OpenRouter."""
         request = ChatCompletionRequest(
             model=model or self.default_model,
             messages=messages,
@@ -126,6 +135,7 @@ class OpenRouterService:
         *,
         model: str | None = None,
     ) -> typing.AsyncIterator[StreamChunk]:
+        """Stream a chat completion from OpenRouter."""
         request = ChatCompletionRequest(
             model=model or self.default_model,
             messages=messages,
@@ -141,11 +151,11 @@ class OpenRouterServiceError(Exception):
 
 
 class OpenRouterServiceTimeoutError(OpenRouterServiceError):
-    pass
+    """Raised when the OpenRouter client times out."""
 
 
 class OpenRouterServiceBadGatewayError(OpenRouterServiceError):
-    pass
+    """Raised when OpenRouter returns a network or server error."""
 
 
 async def chat_with_service(
@@ -155,6 +165,7 @@ async def chat_with_service(
     *,
     model: str | None = None,
 ) -> ChatCompletionResponse:
+    """Safely call ``service.chat_completion`` and map errors."""
     try:
         return await service.chat_completion(api_key, messages, model=model)
     except OpenRouterTimeoutError as exc:
@@ -170,6 +181,7 @@ async def stream_chat_with_service(
     *,
     model: str | None = None,
 ) -> typing.AsyncIterator[StreamChunk]:
+    """Safely call ``service.stream_chat_completion`` and map errors."""
     try:
         async for chunk in service.stream_chat_completion(
             api_key, messages, model=model


### PR DESCRIPTION
## Summary
- document OpenRouter dataclasses
- flesh out OpenRouterService documentation
- describe msgspec helpers and error modules
- add module docs for ORM package

## Testing
- `ruff check src/bournemouth/openrouter_service.py --select D`
- `ruff check src/bournemouth/errors.py --select D`
- `ruff check src/bournemouth/msgspec_support.py --select D`
- `ruff check src/bournemouth/models/__init__.py --select D100`
- `ruff check src/bournemouth/models/mixins.py --select D100`
- `ruff check src/bournemouth/openrouter.py --select D100`
- `pytest -q` *(fails: AssertionError in tests/test_chat_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_685a639fb60083228761b96f2f704bd5

## Summary by Sourcery

Improve documentation coverage by adding comprehensive docstrings across the OpenRouter client, service, msgspec utilities, and ORM modules

Enhancements:
- Add docstrings to OpenRouter API data structures to clarify chat message, tool, and error types
- Add method and class docstrings in OpenRouterService to explain client initialization, context management, and error mapping
- Document msgspec support functions and middleware to outline JSON encoding and request validation
- Add module-level documentation for the ORM package to describe models and mixins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added descriptive docstrings to modules, classes, and functions throughout the codebase to clarify their purpose and usage. No changes were made to application behaviour or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->