### PR TITLE
Refactor streaming helpers

### DIFF
--- a/src/bournemouth/chat_utils.py
+++ b/src/bournemouth/chat_utils.py
@@ -11,7 +11,7 @@ from msgspec import Struct
 from msgspec import json as msgspec_json
 
 from .chat_service import stream_answer
-from .openrouter import ChatMessage, StreamChoice
+from .openrouter import ChatMessage, StreamChoice, StreamChunk
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import asyncio

--- a/src/bournemouth/chat_utils.py
+++ b/src/bournemouth/chat_utils.py
@@ -58,6 +58,10 @@ class StreamConfig:
     send_lock: asyncio.Lock
     api_key: str
     model: str | None
+    stream_func: typing.Callable[
+        [OpenRouterService, str, list[ChatMessage], typing.Any],
+        typing.AsyncIterator[StreamChunk],
+    ] = stream_answer
 
 
 def build_chat_history(
@@ -76,7 +80,7 @@ async def stream_chat_response(
 ) -> None:
     """Stream chat completions back to the client."""
     try:
-        async for chunk in stream_answer(
+        async for chunk in cfg.stream_func(
             cfg.service,
             cfg.api_key,
             history,

--- a/src/bournemouth/resource_helpers.py
+++ b/src/bournemouth/resource_helpers.py
@@ -1,0 +1,23 @@
+"""Utility helpers for Falcon resources."""
+
+from __future__ import annotations
+
+import typing
+
+import falcon
+
+from .chat_service import load_user_and_api_key
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_api_key(
+    session_factory: typing.Callable[[], AsyncSession], user: str
+) -> str | None:
+    """Return the stored OpenRouter API key for *user* or ``None`` if missing."""
+    try:
+        _, api_key = await load_user_and_api_key(session_factory, user)
+    except falcon.HTTPUnauthorized:
+        return None
+    return api_key

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -40,6 +40,8 @@ from .openrouter import ChatMessage, Role, StreamChunk
 
 _logger = logging.getLogger(__name__)
 
+_MISSING_USER_ERROR = "on_connect must be called before handle_chat"
+
 
 class HttpMessage(msgspec.Struct):
     role: Role
@@ -223,10 +225,10 @@ class ChatWsPachinkoResource(WebSocketResource):
     ) -> None:
         """Handle incoming chat messages over WebSocket."""
         if self._send_lock is None:
-            raise RuntimeError("on_connect must be called before handle_chat")
+            raise RuntimeError(_MISSING_USER_ERROR)
         history = build_chat_history(payload.message, payload.history)
         if self._user is None:
-            raise RuntimeError("on_connect must be called before handle_chat")
+            raise RuntimeError(_MISSING_USER_ERROR)
         api_key = await get_api_key(self._session_factory, self._user)
         if api_key is None:
             async with self._send_lock:

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -35,8 +35,8 @@ from .chat_utils import (
     stream_chat_response,
 )
 from .models import Message, MessageRole, UserAccount
-from .resource_helpers import get_api_key
 from .openrouter import ChatMessage, Role, StreamChunk
+from .resource_helpers import get_api_key
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- reuse `stream_chat_response` for both chat resources
- centralize API key fetching
- expose custom stream function via `StreamConfig`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c37eb8a64832288a13f3674d79a9f

## Summary by Sourcery

Refactor streaming and API key handling by centralizing common logic and parameterizing the stream function.

Enhancements:
- Extract get_api_key helper into resource_helpers to centralize API key retrieval
- Replace inline API key lookup methods with get_api_key across chat resources
- Remove duplicated _stream_chat implementations and use stream_chat_response for all streaming endpoints
- Extend StreamConfig to accept a custom stream function and default it to stream_answer