### PR TITLE
Add Makefile and update docs

### DIFF
--- a/.cursor/global.mdc
+++ b/.cursor/global.mdc
@@ -49,9 +49,9 @@ When implementing changes, adhere to the following testing procedures:
 * **Atomicity:** Aim for small, focused, atomic changes. Each change (and subsequent commit) should represent a single logical unit of work.
 * **Quality Gates:** Before considering a change complete or proposing a commit, ensure it meets the following criteria:
   * For Python files:
-    * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
-    * **Linting:** Passes lint checks (`ruff check` or integrated editor linting).
-    * **Formatting:** Adheres to formatting standards (`ruff format` or integrated editor formatting).
+    * **Testing:** Passes all relevant unit and behavioral tests (`make test`).
+    * **Linting:** Passes lint checks (`make lint` or integrated editor linting).
+    * **Formatting:** Adheres to formatting standards (`make fmt` or integrated editor formatting).
     * **Typechecking:** Passes type checking (`pyright` or integrated editor type checking).
   * For TypeScript files:
     * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
@@ -59,7 +59,7 @@ When implementing changes, adhere to the following testing procedures:
     * **Formatting:** Adheres to formatting standards (`biome check --apply .` or integrated editor formatting).
     * **TypeScript Compilation:** Compiles successfully without TypeScript errors (`tsc --noEmit`).
   * For Markdown files (`.md` only):
-    * **Linting:** Passes lint checks (`markdownlint filename.md` or integrated editor linting).
+    * **Linting:** Passes lint checks (`make markdownlint` or integrated editor linting).
 * **Committing:**
   * Only changes that meet all the quality gates above should be committed.
   * Write clear, descriptive commit messages summarizing the change, following these formatting guidelines:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help all clean build release lint fmt check-fmt markdownlint \
-        tools nixie test
+	tools nixie test
 
 MDLINT ?= markdownlint
 NIXIE ?= nixie
@@ -11,7 +11,9 @@ build release: ## Build artefacts (sdist & wheel)
 
 clean: ## Remove build artifacts
 	rm -rf build dist *.egg-info \
-	       .mypy_cache .pytest_cache .coverage coverage.* htmlcov
+	.mypy_cache .pytest_cache .coverage coverage.* htmlcov \
+	.venv
+	find . -type d -name '__pycache__' -exec rm -rf {} +
 
 define ensure_tool
 $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
@@ -24,6 +26,7 @@ tools:
 	$(call ensure_tool,ty)
 	$(call ensure_tool,$(MDLINT))
 	$(call ensure_tool,$(NIXIE))
+	$(call ensure_tool,pytest)
 
 fmt: tools ## Format sources
 	ruff format
@@ -45,7 +48,7 @@ nixie: ## Validate Mermaid diagrams
 	$(call ensure_tool,$(NIXIE))
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
 
-test: ## Run tests
+test: tools ## Run tests
 	uv run pytest -v
 
 help: ## Show available targets

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ nixie: ## Validate Mermaid diagrams
 	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
 
 test: ## Run tests
-	pytest -q
+	uv run pytest -v
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: help all clean build release lint fmt check-fmt markdownlint \
+        tools nixie test
+
+BUILD_JOBS ?=
+MDLINT ?= markdownlint
+NIXIE ?= nixie
+
+all: release ## Build the release artifact
+
+build: ## Build debug artifact
+	python -m build --sdist --wheel
+
+release: ## Build release artifact
+	python -m build --sdist --wheel
+
+clean: ## Remove build artifacts
+	rm -rf build dist *.egg-info
+
+define ensure_tool
+$(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
+$(error $(1) is required but not installed))
+endef
+
+tools:
+	$(call ensure_tool,mdformat-all)
+	$(call ensure_tool,ruff)
+	$(call ensure_tool,ty)
+
+fmt: tools ## Format sources
+	ruff format
+	mdformat-all
+
+check-fmt: ## Verify formatting
+	ruff format --check
+	mdformat-all --check
+
+lint: ## Run linters
+	ruff check
+	ty check
+
+markdownlint: ## Lint Markdown files
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(MDLINT)
+
+nixie: ## Validate Mermaid diagrams
+	find . -type f -name '*.md' -not -path './target/*' -print0 | xargs -0 $(NIXIE)
+
+test: ## Run tests
+	pytest -q
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \
+	awk 'BEGIN {FS=":"; printf "Available targets:\n"} {printf "  %-20s %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -13,20 +13,17 @@ clean: ## Remove build artifacts
 	rm -rf build dist *.egg-info \
 	.mypy_cache .pytest_cache .coverage coverage.* htmlcov \
 	.venv
-	find . -type d -name '__pycache__' -exec rm -rf {} +
+	find . -type d -name '__pycache__' -exec rm -rf '{}' +
 
 define ensure_tool
 $(if $(shell command -v $(1) >/dev/null 2>&1 && echo y),,\
 $(error $(1) is required but not installed))
 endef
 
-tools:
-	$(call ensure_tool,mdformat-all)
-	$(call ensure_tool,ruff)
-	$(call ensure_tool,ty)
-	$(call ensure_tool,$(MDLINT))
-	$(call ensure_tool,$(NIXIE))
-	$(call ensure_tool,pytest)
+
+tools: ## Verify required CLI tools
+	$(foreach t,mdformat-all ruff ty $(MDLINT) $(NIXIE) pytest uv,$(call ensure_tool,$t))
+	@:
 
 fmt: tools ## Format sources
 	ruff format

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Run the API locally with:
 uv run python -m bournemouth.app
 ```
 
+Common development tasks are exposed via a `Makefile`:
+
+```bash
+make fmt   # format the codebase
+make lint  # run linters
+make test  # execute the test suite
+```
+
+Run `make help` to see all available targets.
+
 The server exposes a `/login` endpoint that accepts HTTP Basic Auth credentials.
 On success it returns a signed `session` cookie used by the middleware to guard
 all other routes except `/health`. The credentials, session secret and timeout

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ uv run python -m bournemouth.app
 Common development tasks are exposed via a `Makefile`:
 
 ```bash
+make tools # verify required CLI tools are installed
 make fmt   # format the codebase
 make lint  # run linters
 make test  # execute the test suite

--- a/docs/conditional-testing.md
+++ b/docs/conditional-testing.md
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: uv sync
       - run: uv run pytest tests/ -m "not cli"
-  
+
   test-cli:
     runs-on: ubuntu-latest
     steps:

--- a/docs/conditional-testing.md
+++ b/docs/conditional-testing.md
@@ -137,6 +137,9 @@ uv run --no-group cli python -m pytest src/bournemouth/unittests/test_cli.py -v
 uv run python -m pytest -m "not cli"
 ```
 
+Alternatively, run `make test` to execute the entire suite using the
+configured environment.
+
 ## Best Practices
 
 1. **Use `pytest.importorskip`** for module-level skipping when the entire test file depends on optional dependencies


### PR DESCRIPTION
## Summary
- add project Makefile with Python-focused tasks
- reference make-based workflows in README and docs
- document quality gates in `.cursor` instructions

## Testing
- `mbake validate Makefile`
- `markdownlint README.md docs/conditional-testing.md .cursor/global.mdc` *(fails: line length violations)*
- `pytest -q` *(fails: missing dependencies)*
- `ruff check` *(fails: 162 errors)*
- `pyright` *(fails: 52 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c631b717c8322885740fc318d44bf

## Summary by Sourcery

Add a project-wide Makefile to standardize development tasks and update documentation to reference the new make targets

Enhancements:
- Introduce Makefile to centralize formatting, linting, testing, building, and diagram validation workflows

Documentation:
- Update README to highlight Makefile commands and `make help`
- Reference `make test` in the conditional-testing guide to run the full suite