### PR TITLE
Improve type hints

### DIFF
--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -24,6 +24,7 @@ from .msgspec_support import (
     json_handler,
 )
 from .openrouter_service import OpenRouterService
+from .openrouter import ChatMessage, StreamChunk
 from .resources import (
     ChatResource,
     ChatStateResource,
@@ -34,7 +35,7 @@ from .resources import (
 from .session import SessionManager
 
 
-class PachinkoApp(asgi.App):
+class PachinkoApp(asgi.App):  # pyright: ignore[reportUntypedBaseClass]
     """Falcon app subclass with ``falcon-pachinko`` support."""
 
     __slots__ = ("__dict__",)
@@ -49,8 +50,8 @@ def create_app(
     openrouter_service: OpenRouterService | None = None,
     db_session_factory: typing.Callable[[], AsyncSession] | None = None,
     chat_stream_answer: typing.Callable[
-        [OpenRouterService, str, list[typing.Any], typing.Any],
-        typing.AsyncIterator[typing.Any],
+        [OpenRouterService, str, list[ChatMessage], str | None],
+        typing.AsyncIterator[StreamChunk],
     ] = default_stream_answer,
 ) -> asgi.App:
     """Configure and return the Falcon ASGI app.

--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -26,10 +26,11 @@ class AuthMiddleware:
         if req.path in {"/health", "/login"}:
             return
 
-        cookie = req.cookies.get("session")
-        if not cookie:
+        cookie_obj = req.cookies.get("session")
+        if not cookie_obj:
             raise falcon.HTTPUnauthorized()
 
+        cookie = typing.cast("str", cookie_obj)  # pyright: ignore[reportUnnecessaryCast]
         user = self._session.verify_cookie(cookie)
         if user is None:
             raise falcon.HTTPUnauthorized()
@@ -42,10 +43,11 @@ class AuthMiddleware:
         if req.path in {"/health", "/login"}:
             return
 
-        cookie = req.cookies.get("session")
-        if not cookie:
+        cookie_obj = req.cookies.get("session")
+        if not cookie_obj:
             raise falcon.HTTPUnauthorized()
 
+        cookie = typing.cast("str", cookie_obj)  # pyright: ignore[reportUnnecessaryCast]
         user = self._session.verify_cookie(cookie)
         if user is None:
             raise falcon.HTTPUnauthorized()
@@ -62,14 +64,14 @@ class LoginResource:
         self._password = password
 
     async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
-        auth_header = req.get_header("Authorization") or ""
+        auth_header: str = req.get_header("Authorization") or ""
         prefix = "Basic "
         if not auth_header.startswith(prefix):
             raise falcon.HTTPUnauthorized()
 
         try:
-            encoded = auth_header[len(prefix) :]
-            decoded_bytes = base64.b64decode(encoded)
+            encoded = typing.cast("str", auth_header[len(prefix) :])  # pyright: ignore[reportUnnecessaryCast]
+            decoded_bytes = base64.b64decode(encoded.encode())
             decoded = decoded_bytes.decode()
             username, password = decoded.split(":", 1)
         except (binascii.Error, ValueError):

--- a/src/bournemouth/chat_utils.py
+++ b/src/bournemouth/chat_utils.py
@@ -31,7 +31,7 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
-class ChatWsRequest(Struct):
+class ChatWsRequest(Struct):  # pyright: ignore[reportUntypedBaseClass]
     """Request payload for websocket chat."""
 
     transaction_id: str
@@ -40,7 +40,7 @@ class ChatWsRequest(Struct):
     history: list[ChatMessage] | None = None
 
 
-class ChatWsResponse(Struct):
+class ChatWsResponse(Struct):  # pyright: ignore[reportUntypedBaseClass]
     """Response fragment sent over websocket."""
 
     transaction_id: str
@@ -59,7 +59,7 @@ class StreamConfig:
     api_key: str
     model: str | None
     stream_func: typing.Callable[
-        [OpenRouterService, str, list[ChatMessage], typing.Any],
+        [OpenRouterService, str, list[ChatMessage], str | None],
         typing.AsyncIterator[StreamChunk],
     ] = stream_answer
 
@@ -113,6 +113,6 @@ async def stream_chat_response(
     ) as exc:  # pragma: no cover - passthrough
         _logger.exception(
             "closing websocket due to upstream error",
-            exc_info=exc,
+            exc_info=typing.cast("BaseException", exc),
         )
         await cfg.ws.close(code=1011)


### PR DESCRIPTION
## Summary
- tighten type hints on the chat API app factory
- narrow callable signatures in `chat_utils` and `resources`
- clarify types for auth middleware
- silence pyright unknown argument errors

## Testing
- `pyright src/bournemouth/auth.py src/bournemouth/chat_utils.py src/bournemouth/resources.py src/bournemouth/app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'falcon_pachinko')*

------
https://chatgpt.com/codex/tasks/task_e_685c6f0121a88322aebc5f2ac655ff7a

## Summary by Sourcery

Improve type safety and silence static analysis errors by tightening and clarifying type hints across the chat API app factory, resources, chat utilities, and authentication middleware.

Enhancements:
- Add pyright ignore directives and typing.cast calls to msgspec.Struct subclasses and Falcon ASGI WebSocket types to suppress unknown argument errors
- Narrow stream function and handler callable signatures to concrete types (e.g., str | None) for chat utilities and resources
- Clarify and enforce cookie and session types in auth middleware by renaming variables and casting to str
- Refine factory signature of PachinkoApp to use specific ChatMessage and StreamChunk types