### PR TITLE
Introduce type aliases for chat API

### DIFF
--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover - for type checking only
     from sqlalchemy.ext.asyncio import AsyncSession
 
 from .auth import AuthMiddleware, LoginResource
-from .chat_service import stream_answer as default_stream_answer
+from .chat_service import StreamFunc, stream_answer as default_stream_answer
 from .errors import handle_http_error, handle_unexpected_error
 from .msgspec_support import (
     AsyncMsgspecMiddleware,
@@ -49,10 +49,7 @@ def create_app(
     login_password: str | None = None,
     openrouter_service: OpenRouterService | None = None,
     db_session_factory: typing.Callable[[], AsyncSession] | None = None,
-    chat_stream_answer: typing.Callable[
-        [OpenRouterService, str, list[ChatMessage], str | None],
-        typing.AsyncIterator[StreamChunk],
-    ] = default_stream_answer,
+    chat_stream_answer: StreamFunc = default_stream_answer,
 ) -> asgi.App:
     """Configure and return the Falcon ASGI app.
 

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -26,6 +26,11 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     from .openrouter import ChatMessage, StreamChunk
 
+StreamFunc: typing.TypeAlias = typing.Callable[
+    ["OpenRouterService", str, list["ChatMessage"], str | None],
+    typing.AsyncIterator["StreamChunk"],
+]
+
 
 _logger = logging.getLogger(__name__)
 

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -26,6 +26,19 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     from .openrouter import ChatMessage, StreamChunk
 
+#: Type alias for the streaming function used in OpenRouterService.
+#: 
+#: StreamFunc represents an asynchronous callable with the following signature:
+#:   (service: OpenRouterService, model: str, messages: list[ChatMessage], system_prompt: str | None)
+#:     -> AsyncIterator[StreamChunk]
+#:
+#: - service: The OpenRouterService instance invoking the function.
+#: - model: The model name to use for the chat.
+#: - messages: The list of chat messages to process.
+#: - system_prompt: An optional system prompt string.
+#: - Returns: An async iterator yielding StreamChunk objects.
+#:
+#: If the function signature changes, update this type alias and its documentation accordingly.
 StreamFunc: typing.TypeAlias = typing.Callable[
     ["OpenRouterService", str, list["ChatMessage"], str | None],
     typing.AsyncIterator["StreamChunk"],

--- a/src/bournemouth/chat_utils.py
+++ b/src/bournemouth/chat_utils.py
@@ -7,10 +7,10 @@ import logging
 import typing
 
 import falcon
-from msgspec import Struct
+import msgspec
 from msgspec import json as msgspec_json
 
-from .chat_service import stream_answer
+from .chat_service import StreamFunc, stream_answer
 from .openrouter import ChatMessage, StreamChoice, StreamChunk
 
 if typing.TYPE_CHECKING:  # pragma: no cover
@@ -31,7 +31,10 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
-class ChatWsRequest(Struct):  # pyright: ignore[reportUntypedBaseClass]
+Struct = msgspec.Struct  # pyright: ignore[reportUntypedBaseClass]
+
+
+class ChatWsRequest(Struct):
     """Request payload for websocket chat."""
 
     transaction_id: str
@@ -40,7 +43,7 @@ class ChatWsRequest(Struct):  # pyright: ignore[reportUntypedBaseClass]
     history: list[ChatMessage] | None = None
 
 
-class ChatWsResponse(Struct):  # pyright: ignore[reportUntypedBaseClass]
+class ChatWsResponse(Struct):
     """Response fragment sent over websocket."""
 
     transaction_id: str
@@ -58,10 +61,7 @@ class StreamConfig:
     send_lock: asyncio.Lock
     api_key: str
     model: str | None
-    stream_func: typing.Callable[
-        [OpenRouterService, str, list[ChatMessage], str | None],
-        typing.AsyncIterator[StreamChunk],
-    ] = stream_answer
+    stream_func: StreamFunc = stream_answer
 
 
 def build_chat_history(

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -126,7 +126,7 @@ class ChatResource:
     async def on_websocket(
         self, req: falcon.asgi.Request, ws: falcon.asgi.WebSocket
     ) -> None:
-        encoder: MsgEncoder = typing.cast(MsgEncoder, req.context.msgspec_encoder)
+        encoder: MsgEncoder = typing.cast("MsgEncoder", req.context.msgspec_encoder)
         decoder = msgspec_json.Decoder(ChatWsRequest)
         await ws.accept()
         send_lock = asyncio.Lock()

--- a/src/bournemouth/resources.py
+++ b/src/bournemouth/resources.py
@@ -16,10 +16,13 @@ from msgspec import json as msgspec_json
 from sqlalchemy import update
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from falcon.asgi import WebSocket
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from .openrouter_service import OpenRouterService
+
+Struct = msgspec.Struct  # pyright: ignore[reportUntypedBaseClass]
+WebSocket = falcon.asgi.WebSocket  # pyright: ignore[reportUnknownArgumentType]
+MsgEncoder = msgspec_json.Encoder  # pyright: ignore[reportUnknownArgumentType]
 
 from .chat_service import (
     generate_answer,
@@ -27,6 +30,7 @@ from .chat_service import (
     list_conversation_messages,
     load_user_and_api_key,
     stream_answer,
+    StreamFunc,
 )
 from .chat_utils import (
     ChatWsRequest,
@@ -44,12 +48,12 @@ _logger = logging.getLogger(__name__)
 _MISSING_USER_ERROR = "on_connect must be called before handle_chat"
 
 
-class HttpMessage(msgspec.Struct):  # pyright: ignore[reportUntypedBaseClass]
+class HttpMessage(Struct):
     role: Role
     content: str
 
 
-class ChatRequest(msgspec.Struct):  # pyright: ignore[reportUntypedBaseClass]
+class ChatRequest(Struct):
     """Request body for the chat endpoint."""
 
     message: str
@@ -57,11 +61,11 @@ class ChatRequest(msgspec.Struct):  # pyright: ignore[reportUntypedBaseClass]
     model: str | None = None
 
 
-class TokenRequest(msgspec.Struct):  # pyright: ignore[reportUntypedBaseClass]
+class TokenRequest(Struct):
     api_key: str
 
 
-class ChatStateRequest(msgspec.Struct):  # pyright: ignore[reportUntypedBaseClass]
+class ChatStateRequest(Struct):
     """Request body for the stateful chat endpoint."""
 
     message: str
@@ -83,10 +87,7 @@ class ChatResource:
         service: OpenRouterService,
         session_factory: typing.Callable[[], AsyncSession],
         *,
-        stream_answer_func: typing.Callable[
-            [OpenRouterService, str, list[ChatMessage], str | None],
-            typing.AsyncIterator[StreamChunk],
-        ] = stream_answer,
+        stream_answer_func: StreamFunc = stream_answer,
     ) -> None:
         self._service = service
         self._session_factory = session_factory
@@ -125,7 +126,7 @@ class ChatResource:
     async def on_websocket(
         self, req: falcon.asgi.Request, ws: falcon.asgi.WebSocket
     ) -> None:
-        encoder = typing.cast("msgspec_json.Encoder", req.context.msgspec_encoder)
+        encoder: MsgEncoder = typing.cast(MsgEncoder, req.context.msgspec_encoder)
         decoder = msgspec_json.Decoder(ChatWsRequest)
         await ws.accept()
         send_lock = asyncio.Lock()
@@ -153,8 +154,8 @@ class ChatResource:
                 return
             cfg = StreamConfig(
                 self._service,
-                typing.cast("WebSocket", ws),  # pyright: ignore[reportUnknownArgumentType,reportUnnecessaryCast]
-                typing.cast("msgspec_json.Encoder", encoder),  # pyright: ignore[reportUnknownArgumentType,reportUnnecessaryCast]
+                ws,
+                encoder,
                 send_lock,
                 api_key,
                 request.model,
@@ -166,7 +167,7 @@ class ChatResource:
             while True:
                 raw = await ws.receive_text()
                 raw_bytes: bytes = raw.encode()
-                decoded_request = typing.cast("ChatWsRequest", decoder.decode(raw_bytes))  # pyright: ignore[reportUnnecessaryCast]
+                decoded_request = decoder.decode(raw_bytes)
                 task = asyncio.create_task(handle(decoded_request))
                 tasks.add(task)
                 task.add_done_callback(_finalize_task)
@@ -244,8 +245,8 @@ class ChatWsPachinkoResource(WebSocketResource):  # pyright: ignore[reportUntype
             return
         cfg = StreamConfig(
             self._service,
-            typing.cast("WebSocket", ws),  # pyright: ignore[reportUnknownArgumentType,reportUnnecessaryCast]
-            typing.cast("msgspec_json.Encoder", self._encoder),  # pyright: ignore[reportUnknownArgumentType,reportUnnecessaryCast]
+            ws,
+            self._encoder,
             self._send_lock,
             api_key,
             payload.model,


### PR DESCRIPTION
## Summary
- define a `StreamFunc` callback alias in `chat_service`
- use `StreamFunc` in `app`, `chat_utils`, and `resources`
- add module aliases for `Struct`, `WebSocket`, and encoder types

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `ruff check` *(fails: found 173 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c7e4c746c83229387d42989af347b

## Summary by Sourcery

Introduce and adopt type aliases to streamline type annotations for the chat API

New Features:
- Define StreamFunc type alias for chat streaming callbacks
- Add module-level aliases for msgspec.Struct, msgspec_json.Encoder, and Falcon WebSocket

Enhancements:
- Replace explicit typing.Callable annotations and typing.cast calls with the new StreamFunc alias
- Use the Struct alias for msgspec.Struct-based models
- Remove redundant casts when decoding chat requests