### PR TITLE
Add numpy style docstrings

### DIFF
--- a/src/bournemouth/auth.py
+++ b/src/bournemouth/auth.py
@@ -20,9 +20,30 @@ class AuthMiddleware:
     """Require a valid session cookie for all routes except health and login."""
 
     def __init__(self, session: SessionManager) -> None:
+        """Create middleware with a session manager.
+
+        Parameters
+        ----------
+        session : SessionManager
+            Object used to verify signed session cookies.
+        """
         self._session = session
 
     async def process_request(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """Validate a session cookie for HTTP requests.
+
+        Parameters
+        ----------
+        req : falcon.Request
+            The incoming request.
+        resp : falcon.Response
+            The outgoing response.
+
+        Raises
+        ------
+        falcon.HTTPUnauthorized
+            If the session cookie is missing or invalid.
+        """
         if req.path in {"/health", "/login"}:
             return
 
@@ -40,6 +61,20 @@ class AuthMiddleware:
     async def process_request_ws(
         self, req: falcon.Request, ws: falcon.asgi.WebSocket
     ) -> None:
+        """Validate a session cookie for WebSocket connections.
+
+        Parameters
+        ----------
+        req : falcon.Request
+            The HTTP request associated with the WebSocket.
+        ws : falcon.asgi.WebSocket
+            The WebSocket connection.
+
+        Raises
+        ------
+        falcon.HTTPUnauthorized
+            If the session cookie is missing or invalid.
+        """
         if req.path in {"/health", "/login"}:
             return
 
@@ -59,11 +94,36 @@ class LoginResource:
     """Authenticate via Basic Auth and set a signed session cookie."""
 
     def __init__(self, session: SessionManager, user: str, password: str) -> None:
+        """Initialize the resource with credentials and session manager.
+
+        Parameters
+        ----------
+        session : SessionManager
+            Manager used to create signed cookies.
+        user : str
+            Username permitted to log in.
+        password : str
+            Password for ``user``.
+        """
         self._session = session
         self._user = user
         self._password = password
 
     async def on_post(self, req: falcon.Request, resp: falcon.Response) -> None:
+        """Authenticate using Basic Auth and set a session cookie.
+
+        Parameters
+        ----------
+        req : falcon.Request
+            The incoming request containing the ``Authorization`` header.
+        resp : falcon.Response
+            The HTTP response object to populate.
+
+        Raises
+        ------
+        falcon.HTTPUnauthorized
+            If credentials are missing or invalid.
+        """
         auth_header: str = req.get_header("Authorization") or ""
         prefix = "Basic "
         if not auth_header.startswith(prefix):

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -50,7 +50,6 @@ async def load_user_and_api_key(
     user_sub: str,
 ) -> tuple[uuid.UUID, str | None]:
     """Return the user's ID and decrypted OpenRouter API key."""
-
     async with session_factory() as session:
         stmt = select(UserAccount.id, UserAccount.openrouter_token_enc).where(
             UserAccount.google_sub == user_sub
@@ -75,7 +74,6 @@ async def generate_answer(
     model: str | None,
 ) -> str:
     """Call the chat service and return the assistant's reply."""
-
     async with _convert_service_errors():
         completion = await chat_with_service(service, api_key, messages, model=model)
 
@@ -91,7 +89,6 @@ async def stream_answer(
     model: str | None,
 ) -> typing.AsyncIterator[StreamChunk]:
     """Yield streamed chat chunks while mapping service errors to HTTP errors."""
-
     async with _convert_service_errors():
         async for chunk in stream_chat_with_service(
             service, api_key, messages, model=model
@@ -105,7 +102,6 @@ async def get_or_create_conversation(
     user_id: uuid.UUID,
 ) -> Conversation:
     """Return an existing conversation or create a new one."""
-
     conv: Conversation | None = None
     if conv_id is not None:
         conv = await session.get(Conversation, conv_id)
@@ -126,7 +122,6 @@ async def list_conversation_messages(
     conv_id: uuid.UUID,
 ) -> list[Message]:
     """Return messages for ``conv_id`` ordered by creation time."""
-
     stmt = (
         select(Message)
         .where(Message.conversation_id == conv_id)

--- a/src/bournemouth/cli.py
+++ b/src/bournemouth/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface helpers for the chat server."""
+
 from __future__ import annotations
 
 import dataclasses as dc
@@ -58,6 +60,7 @@ async def _login_request(session: Session, username: str, password: str) -> str:
 
 
 async def token_request(session: Session, token: str) -> bool:
+    """Send a token to the server and return whether it was stored."""
     resp = await _post(
         session,
         "/auth/openrouter-token",
@@ -69,6 +72,7 @@ async def token_request(session: Session, token: str) -> bool:
 async def chat_request(
     session: Session, message: str, history: list[dict[str, str]]
 ) -> str:
+    """Send a chat request and return the assistant's reply."""
     resp = await _post(
         session,
         "/chat",
@@ -83,6 +87,7 @@ async def chat_request(
 async def perform_login(
     host: str, username: str, password: str, cookie_file: Path = COOKIE_PATH
 ) -> str:
+    """Log in to the server and persist the session cookie."""
     cookie = await _login_request(Session(host), username, password)
     cookie_file.write_text(cookie)
     if os.name == "posix":

--- a/src/bournemouth/models/__init__.py
+++ b/src/bournemouth/models/__init__.py
@@ -29,6 +29,8 @@ class Base(DeclarativeBase):
 
 
 class AuditEventType(enum.StrEnum):
+    """Categories of events captured for auditing."""
+
     CHAT_REQUEST = enum.auto()
     CHAT_RESPONSE = enum.auto()
     KG_UPDATE_ENQUEUED = enum.auto()
@@ -38,6 +40,8 @@ class AuditEventType(enum.StrEnum):
 
 
 class KgChangeType(enum.StrEnum):
+    """Types of changes applied to the knowledge graph."""
+
     NODE_CREATED = enum.auto()
     NODE_UPDATED = enum.auto()
     REL_CREATED = enum.auto()
@@ -46,12 +50,16 @@ class KgChangeType(enum.StrEnum):
 
 
 class MessageRole(enum.StrEnum):
+    """Roles associated with chat messages."""
+
     USER = "user"
     ASSISTANT = "assistant"
     SYSTEM = "system"
 
 
 class UserAccount(Base, UuidPKMixin, TimestampMixin):
+    """Persisted user profile and authentication data."""
+
     __tablename__ = "user_account"
 
     google_sub: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
@@ -74,6 +82,8 @@ class UserAccount(Base, UuidPKMixin, TimestampMixin):
 
 
 class AuditEvent(Base, CreatedAtMixin):
+    """Record of user activity for auditing."""
+
     __tablename__ = "audit_event"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -93,6 +103,8 @@ class AuditEvent(Base, CreatedAtMixin):
 
 
 class KgChange(Base):
+    """Change made to the knowledge graph."""
+
     __tablename__ = "kg_change"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -118,6 +130,8 @@ class KgChange(Base):
 
 
 class EncKeyHistory(Base, CreatedAtMixin):
+    """History of encryption keys used to store tokens."""
+
     __tablename__ = "enc_key_history"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -127,6 +141,8 @@ class EncKeyHistory(Base, CreatedAtMixin):
 
 
 class Conversation(Base, UuidPKMixin, TimestampMixin):
+    """Thread of related chat messages for a user."""
+
     __tablename__ = "conversation"
 
     user_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -152,6 +168,8 @@ class Conversation(Base, UuidPKMixin, TimestampMixin):
 
 
 class Message(Base, UuidPKMixin, CreatedAtMixin):
+    """Individual chat message within a conversation."""
+
     __tablename__ = "message"
 
     conversation_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/src/bournemouth/msgspec_support.py
+++ b/src/bournemouth/msgspec_support.py
@@ -106,6 +106,13 @@ class MsgspecWebSocketMiddleware:
     """Attach msgspec encoder/decoder to websocket requests."""
 
     def __init__(self, protocol: str = "json") -> None:
+        """Create middleware for encoding and decoding WebSocket payloads.
+
+        Parameters
+        ----------
+        protocol : str, optional
+            Encoding protocol to use. Only ``"json"`` is supported.
+        """
         if protocol != "json":
             raise ValueError(f"Unsupported msgspec protocol: {protocol}")
         self.encoder = msgspec_json.Encoder()

--- a/src/bournemouth/openrouter.py
+++ b/src/bournemouth/openrouter.py
@@ -336,7 +336,7 @@ def _map_status_to_error(status: int) -> type[OpenRouterAPIError]:
 
     Parameters
     ----------
-    status:
+    status : int
         HTTP status code returned by the API.
 
     Returns
@@ -477,7 +477,7 @@ class OpenRouterAsyncClient:
 
         Parameters
         ----------
-        request:
+        request : ChatCompletionRequest
             Data structure describing the completion request.
 
         Returns
@@ -503,7 +503,7 @@ class OpenRouterAsyncClient:
 
         Parameters
         ----------
-        request:
+        request : ChatCompletionRequest
             Data structure describing the completion request.
 
         Yields

--- a/src/bournemouth/openrouter_service.py
+++ b/src/bournemouth/openrouter_service.py
@@ -154,11 +154,11 @@ class OpenRouterService:
 
         Parameters
         ----------
-        api_key:
+        api_key : str
             OpenRouter API key to authenticate the request.
-        messages:
+        messages : list[ChatMessage]
             Conversation history to send to the API.
-        model:
+        model : str or None, optional
             Optional model override.
 
         Returns
@@ -184,11 +184,11 @@ class OpenRouterService:
 
         Parameters
         ----------
-        api_key:
+        api_key : str
             OpenRouter API key to authenticate the request.
-        messages:
+        messages : list[ChatMessage]
             Conversation history to send to the API.
-        model:
+        model : str or None, optional
             Optional model override.
 
         Yields
@@ -229,13 +229,13 @@ async def chat_with_service(
 
     Parameters
     ----------
-    service:
+    service : OpenRouterService
         Service instance used to perform the request.
-    api_key:
+    api_key : str
         OpenRouter API key for authentication.
-    messages:
+    messages : list[ChatMessage]
         Conversation history to send to the API.
-    model:
+    model : str or None, optional
         Optional model override.
 
     Returns
@@ -248,7 +248,7 @@ async def chat_with_service(
     OpenRouterServiceTimeoutError
         If the request times out.
     OpenRouterServiceBadGatewayError
-        When OpenRouter returns a network, server, or API-level error.
+        When OpenRouter returns a network or server error.
     """
     try:
         return await service.chat_completion(api_key, messages, model=model)
@@ -269,13 +269,13 @@ async def stream_chat_with_service(
 
     Parameters
     ----------
-    service:
+    service : OpenRouterService
         Service instance used to perform the request.
-    api_key:
+    api_key : str
         OpenRouter API key for authentication.
-    messages:
+    messages : list[ChatMessage]
         Conversation history to send to the API.
-    model:
+    model : str or None, optional
         Optional model override.
 
     Yields
@@ -288,7 +288,7 @@ async def stream_chat_with_service(
     OpenRouterServiceTimeoutError
         If the request times out.
     OpenRouterServiceBadGatewayError
-        When OpenRouter returns a network, server, or API-level error.
+        When OpenRouter returns a network or server error.
     """
     try:
         async for chunk in service.stream_chat_completion(

--- a/src/bournemouth/session.py
+++ b/src/bournemouth/session.py
@@ -13,6 +13,15 @@ class SessionManager:
     """Create and verify session cookies."""
 
     def __init__(self, secret: str, timeout: int) -> None:
+        """Initialize the manager with a secret and timeout.
+
+        Parameters
+        ----------
+        secret : str
+            Secret key used to sign cookies.
+        timeout : int
+            Expiration time in seconds.
+        """
         self._serializer = URLSafeTimedSerializer(secret)
         self.timeout = timeout
 

--- a/src/bournemouth/unittests/test_cli.py
+++ b/src/bournemouth/unittests/test_cli.py
@@ -1,3 +1,4 @@
+"""Unit tests for CLI helper functions."""
 from __future__ import annotations
 
 import json
@@ -20,6 +21,7 @@ if typing.TYPE_CHECKING:
 
 @pytest.mark.asyncio  # pyright: ignore[reportUntypedFunctionDecorator]
 async def test_login_saves_cookie(httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+    """Login should store the session cookie on disk."""
     cookie_file = tmp_path / "cookie"
     httpx_mock.add_response(
         method="POST",
@@ -39,6 +41,7 @@ async def test_login_saves_cookie(httpx_mock: HTTPXMock, tmp_path: Path) -> None
 
 @pytest.mark.asyncio  # pyright: ignore[reportUntypedFunctionDecorator]
 async def test_token_posts_correctly(httpx_mock: HTTPXMock) -> None:
+    """Token requests should post the API key with the session cookie."""
     httpx_mock.add_response(
         method="POST",
         url="http://localhost:8000/auth/openrouter-token",
@@ -57,6 +60,7 @@ async def test_token_posts_correctly(httpx_mock: HTTPXMock) -> None:
 
 @pytest.mark.asyncio  # pyright: ignore[reportUntypedFunctionDecorator]
 async def test_chat_sends_history(httpx_mock: HTTPXMock) -> None:
+    """Chat requests should include message history."""
     httpx_mock.add_response(
         method="POST",
         url="http://localhost:8000/chat",

--- a/src/bournemouth/unittests/test_session.py
+++ b/src/bournemouth/unittests/test_session.py
@@ -1,3 +1,4 @@
+"""Unit tests for session cookie management."""
 from __future__ import annotations
 
 from freezegun import freeze_time
@@ -6,12 +7,14 @@ from bournemouth.session import SessionManager
 
 
 def test_cookie_roundtrip() -> None:
+    """A generated cookie should round-trip correctly."""
     mgr = SessionManager("secret", 10)
     cookie = mgr.create_cookie("alice")
     assert mgr.verify_cookie(cookie) == "alice"
 
 
 def test_cookie_expiry() -> None:
+    """Expired cookies should not validate."""
     with freeze_time() as frozen:
         mgr = SessionManager("secret", 1)
         cookie = mgr.create_cookie("alice")
@@ -20,6 +23,7 @@ def test_cookie_expiry() -> None:
 
 
 def test_cookie_bad_signature_with_different_secret() -> None:
+    """Verification fails if the secret differs."""
     mgr1 = SessionManager("secret1", 10)
     mgr2 = SessionManager("secret2", 10)
     cookie = mgr1.create_cookie("alice")
@@ -27,6 +31,7 @@ def test_cookie_bad_signature_with_different_secret() -> None:
 
 
 def test_cookie_bad_signature_when_tampered() -> None:
+    """Tampering with the cookie invalidates the signature."""
     mgr = SessionManager("secret", 10)
     cookie = mgr.create_cookie("alice")
     tampered = cookie + "tamper"

--- a/src/uuid_extensions.py
+++ b/src/uuid_extensions.py
@@ -16,11 +16,15 @@ except ImportError:  # pragma: no cover
 def uuid7(*, return_type: str | None = None) -> uuid.UUID | str:
     """Return a UUIDv7 identifier or a string representation.
 
-    Args:
-        return_type: Specify ``"uuid"`` to return a :class:`uuid.UUID` object,
-            anything else yields the hex string.
+    Parameters
+    ----------
+    return_type : str or None, optional
+        Specify ``"uuid"`` to return a :class:`uuid.UUID` object. Anything else
+        yields the hex string.
 
-    Returns:
+    Returns
+    -------
+    uuid.UUID or str
         A UUID object or string value depending on ``return_type``.
     """
     u = _uuid7()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+"""Shared pytest fixtures for the test suite."""
 import sys
 import typing
 from pathlib import Path
@@ -22,6 +23,7 @@ pytest_plugins = ["pytest_httpx"]
 async def db_session_factory() -> typing.AsyncIterator[
     typing.Callable[[], AsyncSession]
 ]:
+    """Yield a factory that provides a new database session."""
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
     async with engine.begin() as conn, async_session_factory() as session:

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,3 +1,4 @@
+"""Integration tests for authentication and session handling."""
 from __future__ import annotations
 
 import base64
@@ -25,6 +26,7 @@ type SessionFactory = typing.Callable[[], AsyncSession]
 async def test_login_sets_cookie(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Valid credentials should set a session cookie."""
     app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:adminpass").decode()
     async with AsyncClient(
@@ -42,6 +44,7 @@ async def test_login_sets_cookie(
 async def test_login_rejects_bad_credentials(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Incorrect credentials result in 401."""
     app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:wrong").decode()
     async with AsyncClient(
@@ -58,6 +61,7 @@ async def test_login_rejects_bad_credentials(
 async def test_protected_endpoint_requires_cookie(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Protected endpoints require authentication."""
     app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]
@@ -71,6 +75,7 @@ async def test_protected_endpoint_requires_cookie(
 async def test_empty_session_cookie_rejected(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Empty session cookies are treated as invalid."""
     app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
@@ -86,6 +91,7 @@ async def test_chat_with_valid_session(
     httpx_mock: HTTPXMock,
     db_session_factory: SessionFactory,
 ) -> None:
+    """Chat endpoint works when a valid session is provided."""
     app = create_app(db_session_factory=db_session_factory)
     credentials = base64.b64encode(b"admin:adminpass").decode()
     httpx_mock.add_response(
@@ -118,6 +124,7 @@ async def test_chat_with_valid_session(
 async def test_health_does_not_require_auth(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Health checks should be accessible without authentication."""
     app = create_app(db_session_factory=db_session_factory)
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),  # pyright: ignore[reportUnknownArgumentType]

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -1,3 +1,5 @@
+"""Tests for the WebSocket chat endpoint."""
+
 import asyncio
 import base64
 import typing
@@ -20,11 +22,13 @@ type SessionFactory = typing.Callable[[], AsyncSession]
 
 @pytest.fixture()
 def app(db_session_factory: SessionFactory) -> asgi.App:
+    """Create an application instance for testing."""
     return create_app(db_session_factory=db_session_factory)
 
 
 @pytest.fixture()
 def conductor(app: asgi.App) -> testing.ASGIConductor:
+    """Return an ASGI conductor for WebSocket testing."""
     return testing.ASGIConductor(app)
 
 
@@ -97,6 +101,7 @@ def _patch_stream() -> typing.Callable[..., typing.AsyncIterator[StreamChunk]]:
 async def test_websocket_streams_chat(
     app: asgi.App, conductor: testing.ASGIConductor, httpx_mock: HTTPXMock
 ) -> None:
+    """Messages should be streamed to the client over WebSocket."""
     content = (
         b'data: {"id": "1", "object": "chat.completion.chunk", '
         b'"created": 1, "model": "m", "choices": [{"index": 0, '
@@ -134,6 +139,7 @@ async def test_websocket_streams_chat(
 async def test_websocket_multiplexes_requests(
     db_session_factory: SessionFactory,
 ) -> None:
+    """Multiple concurrent requests should receive independent streams."""
     fake_stream = _patch_stream()
     app = create_app(
         db_session_factory=db_session_factory,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,4 @@
+"""Tests for SQLAlchemy models."""
 from __future__ import annotations
 
 import uuid
@@ -19,6 +20,7 @@ from bournemouth.models import (
 
 
 def test_metadata_creates_tables() -> None:
+    """Metadata should create all expected tables."""
     engine = sa.create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     inspector = sa.inspect(engine)
@@ -34,6 +36,7 @@ def test_metadata_creates_tables() -> None:
 
 
 def test_insert_user_and_message() -> None:
+    """Inserting a user and messages should persist rows."""
     engine = sa.create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     with Session(engine) as session:
@@ -52,6 +55,7 @@ def test_insert_user_and_message() -> None:
 
 
 def test_unique_constraints() -> None:
+    """Duplicate values should raise ``IntegrityError``."""
     engine = sa.create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     with Session(engine) as session:
@@ -70,6 +74,7 @@ def test_unique_constraints() -> None:
 
 
 def test_persistence_other_models() -> None:
+    """Other models can be inserted and retrieved."""
     engine = sa.create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     with Session(engine) as session:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,3 +1,4 @@
+"""Integration tests for REST resources."""
 from __future__ import annotations
 
 import typing
@@ -23,6 +24,7 @@ from bournemouth.models import UserAccount
 
 @pytest.fixture()
 def app(db_session_factory: typing.Callable[[], AsyncSession]) -> asgi.App:
+    """Create an application instance for testing."""
     return create_app(db_session_factory=db_session_factory)
 
 
@@ -37,6 +39,7 @@ async def _login(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_chat_returns_answer(app: asgi.App, httpx_mock: HTTPXMock) -> None:
+    """The chat endpoint should return the assistant's answer."""
     httpx_mock.add_response(
         method="POST",
         url="https://openrouter.ai/api/v1/chat/completions",
@@ -63,6 +66,7 @@ async def test_chat_returns_answer(app: asgi.App, httpx_mock: HTTPXMock) -> None
 
 @pytest.mark.asyncio
 async def test_chat_missing_message(app: asgi.App) -> None:
+    """Requests without a message should fail validation."""
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -76,6 +80,7 @@ async def test_chat_missing_message(app: asgi.App) -> None:
 async def test_store_token(
     app: asgi.App, db_session_factory: typing.Callable[[], AsyncSession]
 ) -> None:
+    """Persist an API token for the authenticated user."""
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -98,6 +103,7 @@ async def test_store_token(
 
 @pytest.mark.asyncio
 async def test_store_token_missing_key(app: asgi.App) -> None:
+    """Omitting the token should return a validation error."""
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -109,6 +115,7 @@ async def test_store_token_missing_key(app: asgi.App) -> None:
 
 @pytest.mark.asyncio
 async def test_store_token_non_string(app: asgi.App) -> None:
+    """Non-string tokens should be rejected."""
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -122,6 +129,7 @@ async def test_store_token_non_string(app: asgi.App) -> None:
 async def test_store_token_empty_string(
     app: asgi.App, db_session_factory: typing.Callable[[], AsyncSession]
 ) -> None:
+    """Empty strings should clear the stored token."""
     async with AsyncClient(
         transport=ASGITransport(app=typing.cast("typing.Any", app)),
         base_url="https://test",
@@ -144,6 +152,7 @@ async def test_store_token_empty_string(
 
 @pytest.mark.asyncio
 async def test_chat_empty_choices(app: asgi.App, httpx_mock: HTTPXMock) -> None:
+    """A lack of choices from the service results in a 502 response."""
     httpx_mock.add_response(
         method="POST",
         url="https://openrouter.ai/api/v1/chat/completions",
@@ -169,6 +178,7 @@ async def test_chat_empty_choices(app: asgi.App, httpx_mock: HTTPXMock) -> None:
 async def test_chat_missing_token(
     app: asgi.App, db_session_factory: typing.Callable[[], AsyncSession]
 ) -> None:
+    """Missing OpenRouter token should yield a 401 response."""
     async with db_session_factory() as session:
         await session.execute(
             update(UserAccount)
@@ -190,6 +200,7 @@ async def test_chat_missing_token(
 async def test_chat_unexpected_error_returns_500(
     app: asgi.App, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Unexpected service errors should map to HTTP 500."""
     async def fail(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         raise RuntimeError("boom")
 

--- a/tests/test_stateful_chat.py
+++ b/tests/test_stateful_chat.py
@@ -1,3 +1,5 @@
+"""Tests for the stateful chat API."""
+
 import base64
 import typing
 import uuid
@@ -17,6 +19,7 @@ from bournemouth.models import Conversation, Message, MessageRole, UserAccount
 
 @pytest.fixture()
 def app(db_session_factory: typing.Callable[[], AsyncSession]) -> asgi.App:
+    """Create an application instance for testing."""
     return create_app(db_session_factory=db_session_factory)
 
 
@@ -35,6 +38,7 @@ async def test_stateful_chat_creates_conversation(
     db_session_factory: typing.Callable[[], AsyncSession],
     httpx_mock: HTTPXMock,
 ) -> None:
+    """A new conversation is created and messages are stored."""
     httpx_mock.add_response(
         method="POST",
         url="https://openrouter.ai/api/v1/chat/completions",
@@ -80,6 +84,7 @@ async def test_stateful_chat_appends(
     db_session_factory: typing.Callable[[], AsyncSession],
     httpx_mock: HTTPXMock,
 ) -> None:
+    """Subsequent messages append to the conversation."""
     httpx_mock.add_response(
         method="POST",
         url="https://openrouter.ai/api/v1/chat/completions",
@@ -141,6 +146,7 @@ async def test_stateful_chat_appends(
 async def test_stateful_chat_missing_token(
     app: asgi.App, db_session_factory: typing.Callable[[], AsyncSession]
 ) -> None:
+    """Return 401 if the user has not stored an API token."""
     async with db_session_factory() as session:
         await session.execute(
             update(UserAccount)
@@ -164,6 +170,7 @@ async def test_stateful_chat_persists_user_message_on_timeout(
     db_session_factory: typing.Callable[[], AsyncSession],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """User messages are persisted even when the service times out."""
     async def fail(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         raise chat_service.OpenRouterServiceTimeoutError("boom")
 
@@ -194,6 +201,7 @@ async def test_stateful_chat_handles_unexpected_error(
     db_session_factory: typing.Callable[[], AsyncSession],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Unexpected service errors are handled gracefully."""
     async def fail(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         raise RuntimeError("boom")
 

--- a/tests/ws_helpers.py
+++ b/tests/ws_helpers.py
@@ -1,20 +1,18 @@
-"""
-Light-weight utilities for asserting against WebSocket streams in pytest.
+"""Utilities for asserting against WebSocket streams in pytest.
 
-Key idea
---------
-Spin up a background *pump* task that feeds every incoming frame into
-an asyncio.Queue.  Tests interact purely with that queue, so we never
-block the event-loop on an unknown recv() - and we only apply a
-deadline once per logical expectation, not on every frame.
+Spin up a background *pump* task that feeds every incoming frame into an
+``asyncio.Queue``. Tests interact with that queue so the event loop is never
+blocked waiting for a frame and deadlines are applied once per expectation.
 
 Usage
 -----
+```
 async with ws_collector(ws) as coll:
     await ws.send_json({"prompt": "Hello"})
     msgs = await coll.collect_until(lambda m: m.get("event") == "done")
     assert "".join(m["content"] for m in msgs if m["event"] == "chunk") \
-           .startswith("Hello")
+        .startswith("Hello")
+```
 
 Licence: ISC (same as project)
 """
@@ -134,5 +132,6 @@ class _Pump:
 
 @contextlib.asynccontextmanager
 async def ws_collector(ws: Any) -> AsyncIterator[_Pump]:
+    """Collect messages from a WebSocket into a queue."""
     async with _Pump(ws) as pump:
         yield pump


### PR DESCRIPTION
## Summary
- enforce numpy docstring style in Ruff configuration
- convert middleware and service docs to numpy format
- fix class spacing and docs across models
- update helper module docstrings for uuid generation

## Testing
- `ruff check --select D .`


------
https://chatgpt.com/codex/tasks/task_e_685c893857988322ba98608fb94113e5

## Summary by Sourcery

Enforce numpy-style docstrings across the codebase and update existing docstrings to follow the new format.

Enhancements:
- Add numpy-style docstring templates to middleware, request handlers, and service functions.
- Convert model class, helper, and utility function docstrings to numpy format with standardized parameter and return sections.
- Update CLI commands and session manager to include numpy-style documentation.
- Revise WebSocket utilities and UUID helper to conform to numpy docstring conventions.

Build:
- Enable numpy docstring style enforcement in Ruff configuration.

Tests:
- Convert test function docstrings to numpy style for fixtures and test cases.