### PR TITLE
Refactor type alias definitions

### DIFF
--- a/.cursor/python-typing.mdc
+++ b/.cursor/python-typing.mdc
@@ -142,8 +142,12 @@ Use the `type` keyword to create type aliases with better IDE and runtime suppor
 ```python
 type StrDict = dict[str, str]
 ```
-
 This replaces `StrDict = TypeAlias = ...` and is preferred in modern Python.
+
+When compatibility with Python < 3.12 is required, keep the older
+``typing.TypeAlias`` syntax and add ``# noqa: UP040`` so ``ruff`` does not flag
+it. Place alias definitions after the import block and group shared aliases in
+``bournemouth.types`` to avoid duplication.
 
 #### `from __future__ import annotations`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ falcon-pachinko = { url = "https://github.com/leynos/falcon-pachinko/releases/do
 
 [tool.pyright]
 typeCheckingMode = "strict"
+pythonVersion = "3.13"
 reportMissingTypeStubs = false
 reportMissingModuleSource = false
 reportMissingImports = false

--- a/src/bournemouth/chat_service.py
+++ b/src/bournemouth/chat_service.py
@@ -8,6 +8,7 @@ import typing
 
 import falcon
 from sqlalchemy import select
+
 from uuid_extensions import uuid7
 
 from .models import Conversation, Message, UserAccount
@@ -26,20 +27,19 @@ if typing.TYPE_CHECKING:  # pragma: no cover
 
     from .openrouter import ChatMessage, StreamChunk
 
-#: Type alias for the streaming function used in OpenRouterService.
-#: 
-#: StreamFunc represents an asynchronous callable with the following signature:
-#:   (service: OpenRouterService, model: str, messages: list[ChatMessage], system_prompt: str | None)
-#:     -> AsyncIterator[StreamChunk]
+#: Type alias for the streaming function used in ``OpenRouterService``.
 #:
-#: - service: The OpenRouterService instance invoking the function.
-#: - model: The model name to use for the chat.
-#: - messages: The list of chat messages to process.
-#: - system_prompt: An optional system prompt string.
-#: - Returns: An async iterator yielding StreamChunk objects.
+#: ``StreamFunc`` represents an async callable with the signature::
 #:
-#: If the function signature changes, update this type alias and its documentation accordingly.
-StreamFunc: typing.TypeAlias = typing.Callable[
+#:     (
+#:         service: OpenRouterService,
+#:         model: str,
+#:         messages: list[ChatMessage],
+#:         system_prompt: str | None,
+#:     ) -> AsyncIterator[StreamChunk]
+#:
+#: Update this alias and its docs if the signature ever changes.
+type StreamFunc = typing.Callable[
     ["OpenRouterService", str, list["ChatMessage"], str | None],
     typing.AsyncIterator["StreamChunk"],
 ]
@@ -54,13 +54,13 @@ async def _convert_service_errors() -> typing.AsyncIterator[None]:
         yield
     except OpenRouterServiceTimeoutError as exc:
         _logger.exception("timeout from OpenRouter", exc_info=exc)
-        raise falcon.HTTPGatewayTimeout() from exc
+        raise falcon.HTTPGatewayTimeout from exc
     except OpenRouterServiceBadGatewayError as exc:
         _logger.exception("bad gateway from OpenRouter", exc_info=exc)
         raise falcon.HTTPBadGateway(description=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - unexpected failures
         _logger.exception("unexpected error from OpenRouter", exc_info=exc)
-        raise falcon.HTTPInternalServerError() from exc
+        raise falcon.HTTPInternalServerError from exc
 
 
 async def load_user_and_api_key(
@@ -124,7 +124,7 @@ async def get_or_create_conversation(
     if conv_id is not None:
         conv = await session.get(Conversation, conv_id)
         if conv is None or conv.user_id != user_id:
-            raise falcon.HTTPNotFound()
+            raise falcon.HTTPNotFound
     if conv is None:
         conv = Conversation(
             id=typing.cast("uuid.UUID", uuid7(return_type="uuid")),

--- a/src/bournemouth/chat_utils.py
+++ b/src/bournemouth/chat_utils.py
@@ -7,16 +7,16 @@ import logging
 import typing
 
 import falcon
-import msgspec
-from msgspec import json as msgspec_json
 
 from .chat_service import StreamFunc, stream_answer
-from .openrouter import ChatMessage, StreamChoice, StreamChunk
+from .openrouter import ChatMessage, StreamChoice
+from .types import Struct
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     import asyncio
 
     from falcon.asgi import WebSocket
+    from msgspec import json as msgspec_json
 
     from .openrouter_service import OpenRouterService
 
@@ -31,10 +31,7 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 
 
-Struct = msgspec.Struct  # pyright: ignore[reportUntypedBaseClass]
-
-
-class ChatWsRequest(Struct):
+class ChatWsRequest(Struct):  # pyright: ignore[reportUntypedBaseClass]
     """Request payload for websocket chat."""
 
     transaction_id: str
@@ -43,7 +40,7 @@ class ChatWsRequest(Struct):
     history: list[ChatMessage] | None = None
 
 
-class ChatWsResponse(Struct):
+class ChatWsResponse(Struct):  # pyright: ignore[reportUntypedBaseClass]
     """Response fragment sent over websocket."""
 
     transaction_id: str

--- a/src/bournemouth/types.py
+++ b/src/bournemouth/types.py
@@ -1,0 +1,10 @@
+"""Shared typing aliases."""
+
+from __future__ import annotations
+
+import msgspec
+
+# Centralised alias for msgspec.Struct used across the project.
+Struct = msgspec.Struct  # pyright: ignore[reportUntypedBaseClass]
+
+__all__ = ["Struct"]


### PR DESCRIPTION
## Summary
- use `type` statement for `StreamFunc`
- centralize `Struct` alias in new module
- document alias style updates
- sort imports and fix unused imports
- ensure pyright uses Python 3.13 features

## Testing
- `ruff format src/bournemouth/chat_service.py src/bournemouth/chat_utils.py src/bournemouth/resources.py src/bournemouth/types.py .cursor/python-typing.mdc --quiet`
- `ruff check src/bournemouth/chat_service.py src/bournemouth/chat_utils.py src/bournemouth/resources.py src/bournemouth/types.py --quiet`
- `pyright src/bournemouth/chat_service.py src/bournemouth/chat_utils.py src/bournemouth/resources.py src/bournemouth/types.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_685c984c728c8322ad04299f1fd0ea6c

## Summary by Sourcery

Refactor and centralize type alias definitions, update typing style across modules, enforce Python 3.13 features in pyright, and clean up imports and exception syntax.

Enhancements:
- Centralize `Struct` alias into a new `types.py` module and update imports accordingly
- Convert `StreamFunc` alias declaration to `type` syntax and refine its documentation
- Add explicit type annotations and `typing.cast` calls for WebSocket and JSON encoder types
- Streamline HTTP exception raising by removing redundant `from exc` clauses
- Sort and remove unused imports across chat service, utils, and resource modules

Build:
- Configure pyright to use Python 3.13 in `pyproject.toml`

Documentation:
- Update docstrings to reflect new alias style and signature formatting