### PR TITLE
Add stateful chat to AsyncAPI spec

### DIFF
--- a/docs/websocket-chat-api-asyncapi.yaml
+++ b/docs/websocket-chat-api-asyncapi.yaml
@@ -111,14 +111,16 @@ components:
           type: string
           description: Correlates request with streamed responses
         conversation_id:
-          type: string
-          format: uuid
-          nullable: true
+          oneOf:
+            - type: string
+              format: uuid
+            - type: 'null'
         message:
           type: string
         model:
-          type: string
-          nullable: true
+          oneOf:
+            - type: string
+            - type: 'null'
       required:
         - transaction_id
         - message
@@ -146,3 +148,4 @@ components:
         - conversation_id
         - role
         - content
+        - finished

--- a/docs/websocket-chat-api-asyncapi.yaml
+++ b/docs/websocket-chat-api-asyncapi.yaml
@@ -23,6 +23,21 @@ channels:
       operationId: receiveChat
       message:
         $ref: '#/components/messages/ChatResponse'
+  chat/state:
+    description: |
+      WebSocket channel for stateful chat messages. Each response
+      fragment belongs to a conversation identified by
+      ``conversation_id``.
+    publish:
+      summary: Send a stateful chat request
+      operationId: sendStatefulChat
+      message:
+        $ref: '#/components/messages/ChatStateRequest'
+    subscribe:
+      summary: Receive streaming stateful chat responses
+      operationId: receiveStatefulChat
+      message:
+        $ref: '#/components/messages/ChatStateResponse'
 components:
   messages:
     ChatRequest:
@@ -38,11 +53,13 @@ components:
     ChatStateRequest:
       name: ChatStateRequest
       title: Stateful chat request
+      description: Initiates or continues a conversation with the assistant
       payload:
         $ref: '#/components/schemas/ChatStateRequest'
     ChatStateResponse:
       name: ChatStateResponse
       title: Stateful chat response fragment
+      description: Streamed response fragment for a stateful conversation
       payload:
         $ref: '#/components/schemas/ChatStateResponse'
   schemas:
@@ -113,12 +130,19 @@ components:
         conversation_id:
           type: string
           format: uuid
-        fragment:
+        role:
+          type: string
+          enum: [system, user, assistant, tool]
+        content:
           type: string
         finished:
           type: boolean
-          description: true when this is the last fragment in the stream
+          description: |
+            Indicates whether this is the last fragment in the stream.
+            This property is included in every response and is true only
+            for the final fragment.
       required:
         - transaction_id
         - conversation_id
-        - fragment
+        - role
+        - content

--- a/docs/websocket-chat-api-asyncapi.yaml
+++ b/docs/websocket-chat-api-asyncapi.yaml
@@ -35,6 +35,16 @@ components:
       title: Chat response fragment
       payload:
         $ref: '#/components/schemas/ChatResponse'
+    ChatStateRequest:
+      name: ChatStateRequest
+      title: Stateful chat request
+      payload:
+        $ref: '#/components/schemas/ChatStateRequest'
+    ChatStateResponse:
+      name: ChatStateResponse
+      title: Stateful chat response fragment
+      payload:
+        $ref: '#/components/schemas/ChatStateResponse'
   schemas:
     ChatRequest:
       type: object
@@ -77,3 +87,38 @@ components:
       required:
         - role
         - content
+    ChatStateRequest:
+      type: object
+      properties:
+        transaction_id:
+          type: string
+          description: Correlates request with streamed responses
+        conversation_id:
+          type: string
+          format: uuid
+          nullable: true
+        message:
+          type: string
+        model:
+          type: string
+          nullable: true
+      required:
+        - transaction_id
+        - message
+    ChatStateResponse:
+      type: object
+      properties:
+        transaction_id:
+          type: string
+        conversation_id:
+          type: string
+          format: uuid
+        fragment:
+          type: string
+        finished:
+          type: boolean
+          description: true when this is the last fragment in the stream
+      required:
+        - transaction_id
+        - conversation_id
+        - fragment


### PR DESCRIPTION
## Summary
- extend the websocket AsyncAPI spec with message definitions for stateful chat

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685f401acdfc8322966e4364166a3a17

## Summary by Sourcery

New Features:
- Add ChatStateRequest and ChatStateResponse components and schemas to support stateful chat in the websocket AsyncAPI spec