### PR TITLE
Switch websocket route to /ws/chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ latency.
 The system comprises a few lightweight services:
 
 1. **chat-api** – A Falcon ASGI app written for Python 3.13. It exposes `/chat`,
-   `/auth/openrouter-token`, and `/health` endpoints. It embeds queries,
+   `/ws/chat`, `/auth/openrouter-token`, and `/health` endpoints. It embeds queries,
    retrieves context from Neo4j and proxies prompts to an LLM via OpenRouter.
 2. **worker** – Processes background tasks such as entity extraction and graph
    updates using asynchronous SQLAlchemy.
@@ -71,5 +71,5 @@ Testing strategies and additional guides live in the `docs/` directory, includin
   for generating embeddings with Hugging Face TEI.
 - [`docs/websocket-chat-api-asyncapi.yaml`](docs/websocket-chat-api-asyncapi.yaml)
   for the WebSocket chat API specification.
-  The `/chat` WebSocket endpoint supports multiplexing so multiple chat
+  The `/ws/chat` WebSocket endpoint supports multiplexing so multiple chat
   transactions can share a single connection.

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ Testing strategies and additional guides live in the `docs/` directory, includin
   for generating embeddings with Hugging Face TEI.
 - [`docs/websocket-chat-api-asyncapi.yaml`](docs/websocket-chat-api-asyncapi.yaml)
   for the WebSocket chat API specification.
-  The `/ws/chat` WebSocket endpoint supports multiplexing so multiple chat
+  The `/ws/chat` WebSocket endpoint supports multiplexing, so multiple chat
   transactions can share a single connection.

--- a/docs/websocket-chat-api-asyncapi.yaml
+++ b/docs/websocket-chat-api-asyncapi.yaml
@@ -4,7 +4,7 @@ info:
   version: '0.1'
 servers:
   local:
-    url: ws://localhost:8000/chat
+    url: ws://localhost:8000/ws/chat
     protocol: ws
     description: Local development server
 channels:

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -110,6 +110,14 @@ def create_app(
         ),
     )
     app.add_route("/chat/state", ChatStateResource(service, db_session_factory))
+    app.add_route(
+        "/ws/chat",
+        ChatWsPachinkoResource(
+            service,
+            db_session_factory,
+            stream_answer_func=chat_stream_answer,
+        ),
+    )
     app_with_ws.add_websocket_route(
         "/ws/chat",
         ChatWsPachinkoResource,

--- a/src/bournemouth/app.py
+++ b/src/bournemouth/app.py
@@ -110,19 +110,12 @@ def create_app(
         ),
     )
     app.add_route("/chat/state", ChatStateResource(service, db_session_factory))
-    app.add_route(
-        "/ws/chat",
-        ChatWsPachinkoResource(
-            service,
-            db_session_factory,
-            stream_answer_func=chat_stream_answer,
-        ),
-    )
     app_with_ws.add_websocket_route(
         "/ws/chat",
         ChatWsPachinkoResource,
         service,
         db_session_factory,
+        stream_answer_func=chat_stream_answer,
     )
     app.add_route("/auth/openrouter-token", OpenRouterTokenResource(db_session_factory))
     app.add_route("/health", HealthResource())

--- a/tests/test_chat_websocket.py
+++ b/tests/test_chat_websocket.py
@@ -126,7 +126,7 @@ async def test_websocket_streams_chat(
         cookie = await _login(client)
 
     headers = {"cookie": f"session={cookie}"}
-    async with conductor.simulate_ws("/chat", headers=headers) as ws:
+    async with conductor.simulate_ws("/ws/chat", headers=headers) as ws:
         req = ChatWsRequest(transaction_id="t1", message="hi")
         await ws.send_text(msgspec_json.encode(req).decode())
         first = msgspec_json.decode(await ws.receive_text(), type=ChatWsResponse)
@@ -156,7 +156,7 @@ async def test_websocket_multiplexes_requests(
 
     headers = {"cookie": f"session={cookie}"}
     async with (
-        conductor.simulate_ws("/chat", headers=headers) as ws,
+        conductor.simulate_ws("/ws/chat", headers=headers) as ws,
         ws_collector(ws) as coll,
     ):
         # Send first request


### PR DESCRIPTION
## Summary
- remove unused websocket routing helpers and expose `/ws/chat` via new resource
- update documentation to reference `/ws/chat`
- adjust websocket tests for the new path
- use `ChatWsPachinkoResource` to handle `/ws/chat`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f3fe06bb88322af22c3bf9cd39302

## Summary by Sourcery

Switch the WebSocket chat endpoint from "/chat" to "/ws/chat", centralize connection handling within ChatWsPachinkoResource with a configurable streaming function, and update all routes, documentation, and tests accordingly.

Enhancements:
- Remove legacy WebSocket routing helpers and consolidate on_websocket logic into ChatWsPachinkoResource
- Add a stream_answer_func parameter to ChatWsPachinkoResource for customizable streaming behavior

Documentation:
- Update README and AsyncAPI spec to reference the new "/ws/chat" endpoint

Tests:
- Adjust WebSocket tests to connect to "/ws/chat" instead of "/chat"